### PR TITLE
fix: add a test for pypi mapping

### DIFF
--- a/src/pypi_mapping/custom_pypi_mapping.rs
+++ b/src/pypi_mapping/custom_pypi_mapping.rs
@@ -10,7 +10,7 @@ use url::Url;
 
 use super::{
     build_pypi_purl_from_package_record, is_conda_forge_record, prefix_pypi_name_mapping,
-    CustomMapping, Reporter,
+    CustomMapping, PurlSource, Reporter,
 };
 
 pub async fn fetch_mapping_from_url<T>(
@@ -120,7 +120,7 @@ fn amend_pypi_purls_for_record(
             // we have a pypi name for it so we record a purl
             if let Some(name) = mapped_name {
                 let purl = PackageUrl::builder(String::from("pypi"), name.to_string())
-                    .with_qualifier("source", "project-defined-mapping")
+                    .with_qualifier("source", PurlSource::ProjectDefinedMapping.as_str())
                     .expect("valid qualifier");
 
                 purls.push(purl.build().expect("valid pypi package url"));

--- a/src/pypi_mapping/mod.rs
+++ b/src/pypi_mapping/mod.rs
@@ -126,6 +126,26 @@ impl MappingSource {
     }
 }
 
+/// This enum represents the source of mapping
+/// it can be user-defined ( custom )
+/// or from prefix.dev ( prefix )
+#[derive(Debug, Clone)]
+pub enum PurlSource {
+    HashMapping,
+    CompressedMapping,
+    ProjectDefinedMapping,
+}
+
+impl PurlSource {
+    fn as_str(&self) -> &str {
+        match self {
+            PurlSource::HashMapping => "hash-mapping",
+            PurlSource::CompressedMapping => "compressed-mapping",
+            PurlSource::ProjectDefinedMapping => "project-defined-mapping",
+        }
+    }
+}
+
 pub async fn amend_pypi_purls(
     client: reqwest::Client,
     mapping_source: &MappingSource,

--- a/src/pypi_mapping/mod.rs
+++ b/src/pypi_mapping/mod.rs
@@ -137,7 +137,7 @@ pub enum PurlSource {
 }
 
 impl PurlSource {
-    fn as_str(&self) -> &str {
+    pub fn as_str(&self) -> &str {
         match self {
             PurlSource::HashMapping => "hash-mapping",
             PurlSource::CompressedMapping => "compressed-mapping",

--- a/src/pypi_mapping/prefix_pypi_name_mapping.rs
+++ b/src/pypi_mapping/prefix_pypi_name_mapping.rs
@@ -15,7 +15,8 @@ use tokio::sync::Semaphore;
 use url::Url;
 
 use super::{
-    build_pypi_purl_from_package_record, custom_pypi_mapping, is_conda_forge_record, Reporter,
+    build_pypi_purl_from_package_record, custom_pypi_mapping, is_conda_forge_record, PurlSource,
+    Reporter,
 };
 
 const STORAGE_URL: &str = "https://conda-mapping.prefix.dev";
@@ -200,7 +201,7 @@ pub fn amend_pypi_purls_for_record(
             if let Some(pypi_names) = &mapped_name.pypi_normalized_names {
                 for pypi_name in pypi_names {
                     let purl = PackageUrl::builder(String::from("pypi"), pypi_name)
-                        .with_qualifier("source", "hash-mapping")
+                        .with_qualifier("source", PurlSource::HashMapping.as_str())
                         .expect("valid qualifier");
                     let built_purl = purl.build().expect("valid pypi package url");
                     // Push the value into the vector
@@ -225,7 +226,7 @@ pub fn amend_pypi_purls_for_record(
             // we record the purl
             if let Some(mapped_name) = possible_mapped_name {
                 let purl = PackageUrl::builder(String::from("pypi"), mapped_name)
-                    .with_qualifier("source", "compressed-mapping")
+                    .with_qualifier("source", PurlSource::CompressedMapping.as_str())
                     .expect("valid qualifier");
                 let built_purl = purl.build().expect("valid pypi package url");
                 purls.push(built_purl);

--- a/tests/solve_group_tests.rs
+++ b/tests/solve_group_tests.rs
@@ -3,7 +3,7 @@ use std::{
     str::FromStr,
 };
 
-use pixi::pypi_mapping::{self};
+use pixi::pypi_mapping::{self, PurlSource};
 use rattler_conda_types::{PackageName, Platform, RepoDataRecord};
 use rattler_lock::DEFAULT_ENVIRONMENT_NAME;
 use serial_test::serial;
@@ -150,7 +150,7 @@ async fn test_purl_are_added_for_pypi() {
                         .qualifiers()
                         .get("source")
                         .unwrap()
-                        == "hash-mapping"
+                        == PurlSource::HashMapping.as_str()
                 );
             }
         });
@@ -376,7 +376,7 @@ async fn test_dont_record_not_present_package_as_purl() {
     // so we test that we also record source=conda-forge-mapping qualifier
     assert_eq!(
         boltons_purl.qualifiers().get("source").unwrap(),
-        "compressed-mapping"
+        PurlSource::CompressedMapping.as_str()
     );
 }
 
@@ -444,7 +444,7 @@ async fn test_we_record_not_present_package_as_purl_for_custom_mapping() {
     assert_eq!(boltons_first_purl.name(), "boltons");
     assert_eq!(
         boltons_first_purl.qualifiers().get("source").unwrap(),
-        "project-defined-mapping"
+        PurlSource::ProjectDefinedMapping.as_str()
     );
 
     let package = packages.pop().unwrap();
@@ -510,7 +510,7 @@ async fn test_custom_mapping_channel_with_suffix() {
             .qualifiers()
             .get("source")
             .unwrap(),
-        "project-defined-mapping"
+        PurlSource::ProjectDefinedMapping.as_str()
     );
 }
 
@@ -560,6 +560,6 @@ async fn test_repo_data_record_channel_with_suffix() {
             .qualifiers()
             .get("source")
             .unwrap(),
-        "project-defined-mapping"
+        PurlSource::ProjectDefinedMapping.as_str()
     );
 }


### PR DESCRIPTION
Add test to verify that we really use hash mapping and also add `PurlSource` struct to hold the source values.