### PR TITLE
Few fixes: support `.yml` and `-f`

### DIFF
--- a/crates/pixi_conda/src/create/input.rs
+++ b/crates/pixi_conda/src/create/input.rs
@@ -96,6 +96,7 @@ impl InputFileKind {
             .map(str::to_ascii_lowercase);
         match ext.as_deref() {
             Some("yaml") => Some(Self::EnvironmentYaml),
+            Some("yml") => Some(Self::EnvironmentYaml),
             Some("txt") => Some(Self::ExplicitFile),
             _ => None,
         }

--- a/crates/pixi_conda/src/create/mod.rs
+++ b/crates/pixi_conda/src/create/mod.rs
@@ -42,7 +42,7 @@ pub struct Args {
 
     /// Read package versions from the given file. Repeated file specifications
     /// can be passed (e.g. --file=file1 --file=file2).
-    #[clap(long,  conflicts_with = "package_spec", num_args = 1.., required = true)]
+    #[clap(long, short, conflicts_with = "package_spec", num_args = 1.., required = true)]
     file: Vec<PathBuf>,
 
     /// Name of environment.


### PR DESCRIPTION
In LFortran we use `environment_linux.yml`, this PR makes it work.

The `-f` is a usual shortcut in `conda` for `--file`, so this PR implements it as well.