### PR TITLE
Use WebClient.DownloadFile in Windows installer and dispose client

### DIFF
--- a/install/install.ps1
+++ b/install/install.ps1
@@ -188,9 +188,10 @@ Write-Host "Getting it from this url: $(Mask-Credentials $DOWNLOAD_URL)"
 Write-Host "The binary will be installed into '$BinDir'"
 
 $TEMP_FILE = [System.IO.Path]::GetTempFileName()
+$webClient = New-Object System.Net.WebClient
 
 try {
-    Invoke-WebRequest -Uri $DOWNLOAD_URL -OutFile $TEMP_FILE
+    $webClient.DownloadFile($DOWNLOAD_URL, $TEMP_FILE)
 
     # Create the install dir if it doesn't exist
     if (!(Test-Path -Path $BinDir)) {
@@ -206,6 +207,7 @@ try {
     Write-Host "Error: '$(Mask-Credentials $DOWNLOAD_URL)' is not available or failed to download"
     exit 1
 } finally {
+    $webClient.Dispose()
     Remove-Item -Path $ZIP_FILE
 }
 


### PR DESCRIPTION
### Motivation
- Improve reliability of the download step in the PowerShell installer and ensure the network client is properly disposed after use.

### Description
- Replace `Invoke-WebRequest -OutFile` with a `System.Net.WebClient` instance and `DownloadFile`, and call `$webClient.Dispose()` in the `finally` block to release resources.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4ed07b858832ea7528fb390d5a394)