### PR TITLE
docs: clarify per-environment activation variables

### DIFF
--- a/docs/reference/pixi_manifest.md
+++ b/docs/reference/pixi_manifest.md
@@ -1033,6 +1033,8 @@ This way when a source distribution depends on `gcc` for example, it's used from
 ## The `activation` table
 
 The activation table is used for specialized activation operations that need to be run when the environment is activated.
+At the top level, `[activation]` is shorthand for `[feature.default.activation]`, so it applies to every environment that includes the default feature.
+To set activation scripts or variables for only some environments, put them on a feature (`[feature.<name>.activation]`) and add that feature to the relevant entries in `[environments]`.
 
 There are two types of activation operations a user can modify in the manifest:
 
@@ -1054,6 +1056,7 @@ These activation operations will be run before the `pixi run` and `pixi shell` c
     And the environment variables are set in the shell that is running the activation script, thus take note when using e.g. `$` or `%`.
 
     If you have scripts or env variable per platform use the [target](#the-target-table) table.
+    If you need them per environment, define them on a feature and include that feature in the desired environments (see [the multi-environment guide](../workspace/multi_environment.md)).
 
 ```toml
 [activation]

--- a/docs/workspace/multi_environment.md
+++ b/docs/workspace/multi_environment.md
@@ -64,7 +64,7 @@ pytest = "*"
 dependencies = {cuda = "x.y.z", cudnn = "12.0"}
 pypi-dependencies = {torch = "1.9.0"}
 platforms = ["linux-64", "osx-arm64"]
-activation = {scripts = ["cuda_activation.sh"]}
+activation = {scripts = ["cuda_activation.sh"], env = {CUDA_HOME = "$CONDA_PREFIX"}}
 system-requirements = {cuda = "12"}
 # Channels concatenate using a priority instead of overwrite, so the default channels are still used.
 # Using the priority the concatenation is controlled, default is 0, the default channels are used last.


### PR DESCRIPTION
### Description

Clarifies in the docs how to set activation scripts and environment variables per environment. Users who hit the "activation table applies to all environments" wording had no clear pointer to the feature-scoped approach that already works today.

Fixes #3215

### How Has This Been Tested?

Docs-only change. Verified the rendered Markdown and the internal link to the multi-environment guide.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation