### PR TITLE
feat: add `lfs` field to pypi & conda git specs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6214,6 +6214,7 @@ dependencies = [
  "pixi_config",
  "pixi_consts",
  "pixi_core",
+ "pixi_git",
  "pixi_install_pypi",
  "pixi_manifest",
  "pixi_pypi_spec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6360,6 +6360,7 @@ dependencies = [
  "itertools 0.14.0",
  "ordermap",
  "pixi_build_types",
+ "pixi_git",
  "pixi_manifest",
  "pixi_spec",
  "rattler_conda_types",

--- a/crates/pixi_api/Cargo.toml
+++ b/crates/pixi_api/Cargo.toml
@@ -21,6 +21,7 @@ pep508_rs = { workspace = true }
 pixi_config = { workspace = true }
 pixi_consts = { workspace = true }
 pixi_core = { workspace = true }
+pixi_git = { workspace = true }
 pixi_install_pypi = { workspace = true }
 pixi_manifest = { workspace = true }
 pixi_pypi_spec = { workspace = true }

--- a/crates/pixi_api/src/workspace/add/mod.rs
+++ b/crates/pixi_api/src/workspace/add/mod.rs
@@ -66,6 +66,7 @@ pub async fn add_conda_dep(
                     git: git.clone(),
                     rev: Some(git_options.reference.clone()),
                     subdirectory: subdirectory.clone(),
+                    lfs: git_options.lfs,
                 };
                 (
                     name.clone(),

--- a/crates/pixi_api/src/workspace/add/options.rs
+++ b/crates/pixi_api/src/workspace/add/options.rs
@@ -22,7 +22,11 @@ pub struct GitOptions {
     pub git: Option<Url>,
     pub reference: GitReference,
     pub subdir: Option<String>,
-    /// Fetch git LFS objects, or defer to the `PIXI_GIT_LFS` env var (`None`).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub lfs: Option<GitLfs>,
+    /// Whether to fetch git LFS objects. Defaults to [`GitLfs::Disabled`].
+    #[serde(default, skip_serializing_if = "is_lfs_disabled")]
+    pub lfs: GitLfs,
+}
+
+fn is_lfs_disabled(lfs: &GitLfs) -> bool {
+    !lfs.is_enabled()
 }

--- a/crates/pixi_api/src/workspace/add/options.rs
+++ b/crates/pixi_api/src/workspace/add/options.rs
@@ -21,4 +21,8 @@ pub struct GitOptions {
     pub git: Option<Url>,
     pub reference: GitReference,
     pub subdir: Option<String>,
+    /// Fetch git LFS objects (`Some(true/false)`) or defer to the
+    /// `PIXI_GIT_LFS` env var (`None`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lfs: Option<bool>,
 }

--- a/crates/pixi_api/src/workspace/add/options.rs
+++ b/crates/pixi_api/src/workspace/add/options.rs
@@ -1,4 +1,5 @@
 use pixi_core::environment::LockFileUsage;
+use pixi_git::GitLfs;
 use pixi_manifest::FeatureName;
 use pixi_spec::GitReference;
 use rattler_conda_types::Platform;
@@ -21,8 +22,7 @@ pub struct GitOptions {
     pub git: Option<Url>,
     pub reference: GitReference,
     pub subdir: Option<String>,
-    /// Fetch git LFS objects (`Some(true/false)`) or defer to the
-    /// `PIXI_GIT_LFS` env var (`None`).
+    /// Fetch git LFS objects, or defer to the `PIXI_GIT_LFS` env var (`None`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub lfs: Option<bool>,
+    pub lfs: Option<GitLfs>,
 }

--- a/crates/pixi_build_backend/src/encoded_source_spec_url.rs
+++ b/crates/pixi_build_backend/src/encoded_source_spec_url.rs
@@ -63,10 +63,11 @@ impl From<EncodedSourceSpecUrl> for SourcePackageSpec {
             };
 
             let subdirectory = pairs.remove("subdirectory").map(|s| s.into_owned());
-            let lfs = pairs.remove("lfs").map(|v| match v.as_ref() {
-                "true" | "1" => pixi_build_types::GitLfs::Enabled,
+            // Absence parses as Disabled (mirrors uv's lockfile pattern).
+            let lfs = match pairs.remove("lfs").as_deref() {
+                Some("true" | "1") => pixi_build_types::GitLfs::Enabled,
                 _ => pixi_build_types::GitLfs::Disabled,
-            });
+            };
             GitSpec {
                 git: git_url,
                 rev,
@@ -114,8 +115,9 @@ impl From<SourcePackageSpec> for EncodedSourceSpecUrl {
                     }
                     _ => {}
                 }
-                if let Some(lfs) = git.lfs {
-                    query_pairs.append_pair("lfs", if lfs.is_enabled() { "true" } else { "false" });
+                // Only emit `lfs=true` when enabled (uv lockfile pattern).
+                if git.lfs.is_enabled() {
+                    query_pairs.append_pair("lfs", "true");
                 }
             }
             pixi_build_types::SourcePackageLocationSpec::Path(path) => {
@@ -160,14 +162,14 @@ mod test {
                 git: "https://github.com/some/repo.git".parse().unwrap(),
                 rev: Some(GitReference::Rev("1234567890abcdef".into())),
                 subdirectory: Some("subdir".into()),
-                lfs: None,
+                lfs: pixi_build_types::GitLfs::Disabled,
             }
             .into(),
             pixi_build_types::GitSpec {
                 git: "https://github.com/some/lfs-repo.git".parse().unwrap(),
                 rev: Some(GitReference::Branch("main".into())),
                 subdirectory: None,
-                lfs: Some(pixi_build_types::GitLfs::Enabled),
+                lfs: pixi_build_types::GitLfs::Enabled,
             }
             .into(),
             pixi_build_types::UrlSpec {

--- a/crates/pixi_build_backend/src/encoded_source_spec_url.rs
+++ b/crates/pixi_build_backend/src/encoded_source_spec_url.rs
@@ -63,10 +63,15 @@ impl From<EncodedSourceSpecUrl> for SourcePackageSpec {
             };
 
             let subdirectory = pairs.remove("subdirectory").map(|s| s.into_owned());
+            let lfs = pairs.remove("lfs").map(|v| match v.as_ref() {
+                "true" | "1" => pixi_build_types::GitLfs::Enabled,
+                _ => pixi_build_types::GitLfs::Disabled,
+            });
             GitSpec {
                 git: git_url,
                 rev,
                 subdirectory,
+                lfs,
             }
             .into()
         } else {
@@ -108,6 +113,9 @@ impl From<SourcePackageSpec> for EncodedSourceSpecUrl {
                         query_pairs.append_pair("tag", tag);
                     }
                     _ => {}
+                }
+                if let Some(lfs) = git.lfs {
+                    query_pairs.append_pair("lfs", if lfs.is_enabled() { "true" } else { "false" });
                 }
             }
             pixi_build_types::SourcePackageLocationSpec::Path(path) => {
@@ -152,6 +160,14 @@ mod test {
                 git: "https://github.com/some/repo.git".parse().unwrap(),
                 rev: Some(GitReference::Rev("1234567890abcdef".into())),
                 subdirectory: Some("subdir".into()),
+                lfs: None,
+            }
+            .into(),
+            pixi_build_types::GitSpec {
+                git: "https://github.com/some/lfs-repo.git".parse().unwrap(),
+                rev: Some(GitReference::Branch("main".into())),
+                subdirectory: None,
+                lfs: Some(pixi_build_types::GitLfs::Enabled),
             }
             .into(),
             pixi_build_types::UrlSpec {

--- a/crates/pixi_build_type_conversions/Cargo.toml
+++ b/crates/pixi_build_type_conversions/Cargo.toml
@@ -13,6 +13,7 @@ version = "0.1.0"
 itertools = { workspace = true }
 ordermap = { workspace = true, features = ["serde"] }
 pixi_build_types = { workspace = true }
+pixi_git = { workspace = true }
 pixi_manifest = { workspace = true }
 pixi_spec = { workspace = true }
 rattler_conda_types = { workspace = true }

--- a/crates/pixi_build_type_conversions/src/project_model.rs
+++ b/crates/pixi_build_type_conversions/src/project_model.rs
@@ -78,10 +78,10 @@ fn to_pixi_spec_v1(
                         // pixi-side enum and protocol enum are bit-for-bit
                         // identical (both wire as bool); map across the
                         // boundary explicitly.
-                        lfs: lfs.map(|p| match p {
+                        lfs: match lfs {
                             pixi_git::GitLfs::Enabled => pbt::GitLfs::Enabled,
                             pixi_git::GitLfs::Disabled => pbt::GitLfs::Disabled,
-                        }),
+                        },
                     })
                 }
                 pixi_spec::SourceLocationSpec::Path(path_source_spec) => {

--- a/crates/pixi_build_type_conversions/src/project_model.rs
+++ b/crates/pixi_build_type_conversions/src/project_model.rs
@@ -64,7 +64,7 @@ fn to_pixi_spec_v1(
                         git,
                         rev,
                         subdirectory,
-                        lfs: _,
+                        lfs,
                     } = git_spec;
                     pbt::SourcePackageLocationSpec::Git(pbt::GitSpec {
                         git,
@@ -75,6 +75,13 @@ fn to_pixi_spec_v1(
                             GitReference::DefaultBranch => pbt::GitReference::DefaultBranch,
                         }),
                         subdirectory: subdirectory.to_option_string(),
+                        // pixi-side enum and protocol enum are bit-for-bit
+                        // identical (both wire as bool); map across the
+                        // boundary explicitly.
+                        lfs: lfs.map(|p| match p {
+                            pixi_git::GitLfs::Enabled => pbt::GitLfs::Enabled,
+                            pixi_git::GitLfs::Disabled => pbt::GitLfs::Disabled,
+                        }),
                     })
                 }
                 pixi_spec::SourceLocationSpec::Path(path_source_spec) => {

--- a/crates/pixi_build_type_conversions/src/project_model.rs
+++ b/crates/pixi_build_type_conversions/src/project_model.rs
@@ -64,6 +64,7 @@ fn to_pixi_spec_v1(
                         git,
                         rev,
                         subdirectory,
+                        lfs: _,
                     } = git_spec;
                     pbt::SourcePackageLocationSpec::Git(pbt::GitSpec {
                         git,

--- a/crates/pixi_build_types/src/lib.rs
+++ b/crates/pixi_build_types/src/lib.rs
@@ -12,8 +12,8 @@ pub use capabilities::{BackendCapabilities, FrontendCapabilities};
 pub use channel_configuration::ChannelConfiguration;
 pub use conda_package_metadata::CondaPackageMetadata;
 pub use project_model::{
-    BinaryPackageSpec, ConstraintSpec, GitReference, GitSpec, NamedSpec, PackageSpec, PathSpec,
-    PinBound, PinCompatibleSpec, PinExpression, ProjectModel, SourcePackageLocationSpec,
+    BinaryPackageSpec, ConstraintSpec, GitLfs, GitReference, GitSpec, NamedSpec, PackageSpec,
+    PathSpec, PinBound, PinCompatibleSpec, PinExpression, ProjectModel, SourcePackageLocationSpec,
     SourcePackageName, SourcePackageSpec, Target, TargetSelector, Targets, UrlSpec,
 };
 use rattler_conda_types::{

--- a/crates/pixi_build_types/src/project_model.rs
+++ b/crates/pixi_build_types/src/project_model.rs
@@ -428,22 +428,27 @@ pub struct GitSpec {
     /// Part of the source identity: an LFS checkout and a non-LFS checkout
     /// at the same commit produce different file trees (pointer files vs
     /// real blobs), so backends building from the URL need to know.
-    /// Defaults to `None` (unset) when the manifest didn't specify; the env
-    /// fallback is resolved on the pixi side before reaching the backend.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub lfs: Option<GitLfs>,
+    /// Defaults to [`GitLfs::Disabled`] and is skipped from serialisation
+    /// in that case, so existing wire payloads round-trip unchanged.
+    #[serde(default, skip_serializing_if = "is_lfs_disabled")]
+    pub lfs: GitLfs,
 }
 
-/// Whether to fetch git LFS objects when checking out a repository. Mirrors
-/// uv's `GitLfs` and pixi's `pixi_git::GitLfs`; wire-serialised as a bool
-/// (`lfs: true`/`lfs: false`) so existing manifests round-trip unchanged.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+fn is_lfs_disabled(lfs: &GitLfs) -> bool {
+    !lfs.is_enabled()
+}
+
+/// Whether to fetch git LFS objects when checking out a repository.
+/// Mirrors uv's `GitLfs` and pixi's `pixi_git::GitLfs`; wire-serialised
+/// as a bool. Defaults to [`GitLfs::Disabled`].
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Default)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum GitLfs {
+    /// Skip git-LFS; pointer files stay as pointers.
+    #[default]
+    Disabled,
     /// Fetch git-LFS objects; materialise pointer files to real blobs.
     Enabled,
-    /// Skip git-LFS; pointer files stay as pointers.
-    Disabled,
 }
 
 impl GitLfs {
@@ -849,7 +854,7 @@ impl Hash for GitSpec {
             .field("git", &self.git)
             .field("rev", &self.rev)
             .field("subdirectory", &self.subdirectory)
-            .field("lfs", &self.lfs.map(bool::from))
+            .field("lfs", &bool::from(self.lfs))
             .finish(state);
     }
 }

--- a/crates/pixi_build_types/src/project_model.rs
+++ b/crates/pixi_build_types/src/project_model.rs
@@ -423,6 +423,60 @@ pub struct GitSpec {
 
     /// The git subdirectory of the package
     pub subdirectory: Option<String>,
+
+    /// Whether the source was checked out with git LFS objects materialised.
+    /// Part of the source identity: an LFS checkout and a non-LFS checkout
+    /// at the same commit produce different file trees (pointer files vs
+    /// real blobs), so backends building from the URL need to know.
+    /// Defaults to `None` (unset) when the manifest didn't specify; the env
+    /// fallback is resolved on the pixi side before reaching the backend.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lfs: Option<GitLfs>,
+}
+
+/// Whether to fetch git LFS objects when checking out a repository. Mirrors
+/// uv's `GitLfs` and pixi's `pixi_git::GitLfs`; wire-serialised as a bool
+/// (`lfs: true`/`lfs: false`) so existing manifests round-trip unchanged.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub enum GitLfs {
+    /// Fetch git-LFS objects; materialise pointer files to real blobs.
+    Enabled,
+    /// Skip git-LFS; pointer files stay as pointers.
+    Disabled,
+}
+
+impl GitLfs {
+    /// `true` for [`GitLfs::Enabled`].
+    pub fn is_enabled(self) -> bool {
+        matches!(self, Self::Enabled)
+    }
+}
+
+impl From<bool> for GitLfs {
+    fn from(b: bool) -> Self {
+        if b { Self::Enabled } else { Self::Disabled }
+    }
+}
+
+impl From<GitLfs> for bool {
+    fn from(lfs: GitLfs) -> Self {
+        lfs.is_enabled()
+    }
+}
+
+// Wire as bool so a `lfs = true/false` manifest round-trips through the
+// JSON-RPC layer without any reformatting.
+impl Serialize for GitLfs {
+    fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        ser.serialize_bool(self.is_enabled())
+    }
+}
+
+impl<'de> Deserialize<'de> for GitLfs {
+    fn deserialize<D: serde::Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        bool::deserialize(de).map(GitLfs::from)
+    }
 }
 
 /// A specification of a package from a path
@@ -795,6 +849,7 @@ impl Hash for GitSpec {
             .field("git", &self.git)
             .field("rev", &self.rev)
             .field("subdirectory", &self.subdirectory)
+            .field("lfs", &self.lfs.map(bool::from))
             .finish(state);
     }
 }

--- a/crates/pixi_cli/src/add.rs
+++ b/crates/pixi_cli/src/add.rs
@@ -119,6 +119,7 @@ impl From<&Args> for GitOptions {
                 .unwrap_or_default()
                 .into(),
             subdir: args.dependency_config.subdir.clone(),
+            lfs: None,
         }
     }
 }
@@ -147,6 +148,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                     .unwrap_or_default()
                     .into(),
                 subdir: args.dependency_config.subdir.clone(),
+                lfs: None,
             };
 
             workspace_ctx

--- a/crates/pixi_cli/src/add.rs
+++ b/crates/pixi_cli/src/add.rs
@@ -119,7 +119,7 @@ impl From<&Args> for GitOptions {
                 .unwrap_or_default()
                 .into(),
             subdir: args.dependency_config.subdir.clone(),
-            lfs: None,
+            lfs: pixi_git::GitLfs::Disabled,
         }
     }
 }
@@ -148,7 +148,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                     .unwrap_or_default()
                     .into(),
                 subdir: args.dependency_config.subdir.clone(),
-                lfs: None,
+                lfs: pixi_git::GitLfs::Disabled,
             };
 
             workspace_ctx

--- a/crates/pixi_cli/src/global/global_specs.rs
+++ b/crates/pixi_cli/src/global/global_specs.rs
@@ -104,6 +104,7 @@ impl GlobalSpecs {
                     .map(Subdirectory::try_from)
                     .transpose()?
                     .unwrap_or_default(),
+                lfs: None,
             };
             Some(PixiSpec::Git(git_spec))
         } else if let Some(path) = &self.path {

--- a/crates/pixi_cli/src/global/global_specs.rs
+++ b/crates/pixi_cli/src/global/global_specs.rs
@@ -1,3 +1,4 @@
+use pixi_git::GitLfs;
 use std::{io, path::Path};
 
 use clap::Parser;
@@ -104,7 +105,7 @@ impl GlobalSpecs {
                     .map(Subdirectory::try_from)
                     .transpose()?
                     .unwrap_or_default(),
-                lfs: None,
+                lfs: GitLfs::Disabled,
             };
             Some(PixiSpec::Git(git_spec))
         } else if let Some(path) = &self.path {

--- a/crates/pixi_command_dispatcher/src/build/conversion.rs
+++ b/crates/pixi_command_dispatcher/src/build/conversion.rs
@@ -66,6 +66,7 @@ pub fn from_source_package_location_spec(
                     .subdirectory
                     .and_then(|s| pixi_spec::Subdirectory::try_from(s).ok())
                     .unwrap_or_default(),
+                lfs: None,
             })
         }
 

--- a/crates/pixi_command_dispatcher/src/build/conversion.rs
+++ b/crates/pixi_command_dispatcher/src/build/conversion.rs
@@ -1,4 +1,5 @@
 use pixi_build_types::{BinaryPackageSpec, SourcePackageLocationSpec, SourcePackageSpec};
+use pixi_git::GitLfs;
 use pixi_spec::{BinarySpec, DetailedSpec, UrlBinarySpec};
 use rattler_conda_types::NamedChannelOrUrl;
 
@@ -66,7 +67,7 @@ pub fn from_source_package_location_spec(
                     .subdirectory
                     .and_then(|s| pixi_spec::Subdirectory::try_from(s).ok())
                     .unwrap_or_default(),
-                lfs: None,
+                lfs: GitLfs::Disabled,
             })
         }
 

--- a/crates/pixi_command_dispatcher/src/installed_source_hints.rs
+++ b/crates/pixi_command_dispatcher/src/installed_source_hints.rs
@@ -42,6 +42,7 @@ use std::{
     sync::{Arc, OnceLock},
 };
 
+use pixi_git::GitLfs;
 use pixi_record::{PinnedBuildSourceSpec, PinnedSourceSpec, UnresolvedPixiRecord};
 use pixi_spec::SourceLocationSpec;
 use rattler_conda_types::PackageName;
@@ -343,7 +344,7 @@ mod tests {
                 commit: GitSha::from_str(commit).expect("valid sha"),
                 subdirectory: Default::default(),
                 reference: GitReference::Branch("main".into()),
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         });
         let data = SourceRecordData::Partial(PartialSourceRecordData {
@@ -374,7 +375,7 @@ mod tests {
             git: url::Url::parse(url).expect("valid git url"),
             rev: Some(GitReference::Branch("main".into())),
             subdirectory: Default::default(),
-            lfs: None,
+            lfs: GitLfs::Disabled,
         })
     }
 

--- a/crates/pixi_command_dispatcher/src/installed_source_hints.rs
+++ b/crates/pixi_command_dispatcher/src/installed_source_hints.rs
@@ -343,6 +343,7 @@ mod tests {
                 commit: GitSha::from_str(commit).expect("valid sha"),
                 subdirectory: Default::default(),
                 reference: GitReference::Branch("main".into()),
+                lfs: None,
             },
         });
         let data = SourceRecordData::Partial(PartialSourceRecordData {
@@ -373,6 +374,7 @@ mod tests {
             git: url::Url::parse(url).expect("valid git url"),
             rev: Some(GitReference::Branch("main".into())),
             subdirectory: Default::default(),
+            lfs: None,
         })
     }
 

--- a/crates/pixi_command_dispatcher/tests/integration/main.rs
+++ b/crates/pixi_command_dispatcher/tests/integration/main.rs
@@ -7,6 +7,7 @@ use std::{
     sync::Arc,
 };
 
+use pixi_git::GitLfs;
 use pixi_path::AbsPathBuf;
 
 use event_reporter::{EventReporter, WithEventReporter};
@@ -229,7 +230,7 @@ pub async fn simple_test() {
                     git: git_repo.url.parse().unwrap(),
                     rev: Some(GitReference::Rev(git_repo.commits[0].clone())),
                     subdirectory: Subdirectory::try_from("recipe").unwrap(),
-                    lfs: None,
+                    lfs: GitLfs::Disabled,
                 }
                 .into(),
             )]),

--- a/crates/pixi_command_dispatcher/tests/integration/main.rs
+++ b/crates/pixi_command_dispatcher/tests/integration/main.rs
@@ -229,6 +229,7 @@ pub async fn simple_test() {
                     git: git_repo.url.parse().unwrap(),
                     rev: Some(GitReference::Rev(git_repo.commits[0].clone())),
                     subdirectory: Subdirectory::try_from("recipe").unwrap(),
+                    lfs: None,
                 }
                 .into(),
             )]),

--- a/crates/pixi_compute_sources/src/git.rs
+++ b/crates/pixi_compute_sources/src/git.rs
@@ -96,30 +96,20 @@ impl LifecycleKind for GitReporterLifecycle {
 }
 
 /// Dedup key for a git checkout. Keyed on the full [`GitUrl`]: URL,
-/// reference, AND `precise` commit, so a caller asking for a specific
-/// commit doesn't collide with one asking only for the branch.
+/// reference, `precise` commit, AND LFS preference (LFS is part of
+/// `GitUrl`'s `Hash`/`Eq`). So a caller asking for a specific commit
+/// doesn't collide with one asking only for the branch, and a caller
+/// asking with LFS doesn't get blocked on a non-LFS sibling's result.
 /// Stripping `precise` from the key let `checkout_pinned_source(A)`
 /// silently return the branch's HEAD instead of commit `A`
 /// (prefix-dev/pixi#6073).
-///
-/// The LFS flag is also part of the key: two callers asking for the same
-/// commit with different `lfs` preferences get distinct compute futures, so
-/// neither blocks on the other's choice (the on-disk DB is still shared via
-/// the path-based lock in `GitResolver::fetch`).
 #[derive(Clone, Debug, Display, Hash, PartialEq, Eq)]
 #[display("{}@{}", _0.repository(), _0.reference())]
-pub struct CheckoutGit(GitUrl, Option<bool>);
+pub struct CheckoutGit(GitUrl);
 
 impl CheckoutGit {
     pub fn new(git_url: &GitUrl) -> Self {
-        Self(git_url.clone(), None)
-    }
-
-    /// Set the LFS preference for this checkout. `None` defers to the
-    /// `PIXI_GIT_LFS` env var; `Some(true/false)` is an explicit override.
-    pub fn with_lfs(mut self, lfs: Option<bool>) -> Self {
-        self.1 = lfs;
-        self
+        Self(git_url.clone())
     }
 }
 
@@ -150,16 +140,11 @@ impl Key for CheckoutGit {
 
         // Pass the original `GitUrl` straight through so the resolver
         // honours `precise` when set (pinned checkout) and advances to
-        // the branch HEAD when not (fresh resolve).
+        // the branch HEAD when not (fresh resolve). LFS preference rides
+        // along on the `GitUrl`.
         Arc::new(
             resolver
-                .fetch(
-                    self.0.clone(),
-                    client,
-                    cache_dir.into_std_path_buf(),
-                    None,
-                    self.1,
-                )
+                .fetch(self.0.clone(), client, cache_dir.into_std_path_buf(), None)
                 .await,
         )
     }
@@ -195,13 +180,13 @@ impl GitSourceCheckoutExt for ComputeCtx {
         let lfs = git_spec.lfs;
 
         let git_url = match GitUrl::try_from(git_spec.git).map_err(GitError::from) {
-            Ok(url) => url.with_reference(git_reference),
+            Ok(url) => url.with_reference(git_reference).with_lfs(lfs),
             Err(e) => {
                 return Either::Left(async move { Err(SourceCheckoutError::from(e)) });
             }
         };
 
-        let fut = self.compute(&CheckoutGit::new(&git_url).with_lfs(lfs));
+        let fut = self.compute(&CheckoutGit::new(&git_url));
         Either::Right(async move {
             let fetch = fut.await.as_ref().clone()?;
             let pinned = PinnedGitSpec {
@@ -225,9 +210,9 @@ impl GitSourceCheckoutExt for ComputeCtx {
             git_spec.git.clone(),
             git_spec.source.reference.clone().into(),
             git_spec.source.commit,
-        );
-        let lfs = git_spec.source.lfs;
-        let fut = self.compute(&CheckoutGit::new(&git_url).with_lfs(lfs));
+        )
+        .with_lfs(git_spec.source.lfs);
+        let fut = self.compute(&CheckoutGit::new(&git_url));
         async move {
             let fetch = fut.await.as_ref().clone()?;
             Ok(SourceCheckout::from_git(fetch, git_spec))

--- a/crates/pixi_compute_sources/src/git.rs
+++ b/crates/pixi_compute_sources/src/git.rs
@@ -101,13 +101,25 @@ impl LifecycleKind for GitReporterLifecycle {
 /// Stripping `precise` from the key let `checkout_pinned_source(A)`
 /// silently return the branch's HEAD instead of commit `A`
 /// (prefix-dev/pixi#6073).
+///
+/// The LFS flag is also part of the key: two callers asking for the same
+/// commit with different `lfs` preferences get distinct compute futures, so
+/// neither blocks on the other's choice (the on-disk DB is still shared via
+/// the path-based lock in `GitResolver::fetch`).
 #[derive(Clone, Debug, Display, Hash, PartialEq, Eq)]
 #[display("{}@{}", _0.repository(), _0.reference())]
-pub struct CheckoutGit(GitUrl);
+pub struct CheckoutGit(GitUrl, Option<bool>);
 
 impl CheckoutGit {
     pub fn new(git_url: &GitUrl) -> Self {
-        Self(git_url.clone())
+        Self(git_url.clone(), None)
+    }
+
+    /// Set the LFS preference for this checkout. `None` defers to the
+    /// `PIXI_GIT_LFS` env var; `Some(true/false)` is an explicit override.
+    pub fn with_lfs(mut self, lfs: Option<bool>) -> Self {
+        self.1 = lfs;
+        self
     }
 }
 
@@ -141,7 +153,13 @@ impl Key for CheckoutGit {
         // the branch HEAD when not (fresh resolve).
         Arc::new(
             resolver
-                .fetch(self.0.clone(), client, cache_dir.into_std_path_buf(), None)
+                .fetch(
+                    self.0.clone(),
+                    client,
+                    cache_dir.into_std_path_buf(),
+                    None,
+                    self.1,
+                )
                 .await,
         )
     }
@@ -174,6 +192,7 @@ impl GitSourceCheckoutExt for ComputeCtx {
             .unwrap_or(GitReference::DefaultBranch);
         let pinned_git_reference = git_spec.rev.clone().unwrap_or_default();
         let subdirectory = git_spec.subdirectory.clone();
+        let lfs = git_spec.lfs;
 
         let git_url = match GitUrl::try_from(git_spec.git).map_err(GitError::from) {
             Ok(url) => url.with_reference(git_reference),
@@ -182,7 +201,7 @@ impl GitSourceCheckoutExt for ComputeCtx {
             }
         };
 
-        let fut = self.compute(&CheckoutGit::new(&git_url));
+        let fut = self.compute(&CheckoutGit::new(&git_url).with_lfs(lfs));
         Either::Right(async move {
             let fetch = fut.await.as_ref().clone()?;
             let pinned = PinnedGitSpec {
@@ -191,6 +210,7 @@ impl GitSourceCheckoutExt for ComputeCtx {
                     commit: fetch.commit(),
                     subdirectory,
                     reference: pinned_git_reference,
+                    lfs,
                 },
             };
             Ok(SourceCheckout::from_git(fetch, pinned))
@@ -206,7 +226,8 @@ impl GitSourceCheckoutExt for ComputeCtx {
             git_spec.source.reference.clone().into(),
             git_spec.source.commit,
         );
-        let fut = self.compute(&CheckoutGit::new(&git_url));
+        let lfs = git_spec.source.lfs;
+        let fut = self.compute(&CheckoutGit::new(&git_url).with_lfs(lfs));
         async move {
             let fetch = fut.await.as_ref().clone()?;
             Ok(SourceCheckout::from_git(fetch, git_spec))

--- a/crates/pixi_compute_sources/tests/git_checkout.rs
+++ b/crates/pixi_compute_sources/tests/git_checkout.rs
@@ -29,6 +29,7 @@ async fn pin_and_checkout_git_default_branch() {
         git: repo.base_url.clone(),
         rev: None,
         subdirectory: Subdirectory::default(),
+        lfs: None,
     };
 
     let checkout = engine
@@ -56,6 +57,60 @@ async fn pin_and_checkout_git_default_branch() {
     }
 }
 
+/// `lfs = Some(true)` on the spec flows through `pin_and_checkout_git` to
+/// `GitSource`, which materialises LFS blobs and records the flag on the
+/// pinned spec for the lock file.
+#[tokio::test]
+async fn pin_and_checkout_git_with_lfs() {
+    let lfs_ok = std::process::Command::new("git")
+        .args(["lfs", "version"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if !lfs_ok {
+        eprintln!("skipping pin_and_checkout_git_with_lfs: git-lfs is not installed");
+        return;
+    }
+
+    let repo = GitRepoFixture::new("lfs-sample");
+    assert!(repo.uses_lfs, "fixture should auto-detect LFS");
+
+    let engine = build_test_engine(EngineConfig {
+        sequential: true,
+        ..Default::default()
+    });
+
+    let spec = GitSpec {
+        git: repo.base_url.clone(),
+        rev: None,
+        subdirectory: Subdirectory::default(),
+        lfs: Some(true),
+    };
+
+    let checkout = engine
+        .with_ctx(async |ctx| ctx.pin_and_checkout_git(spec).await)
+        .await
+        .expect("engine scope")
+        .expect("git checkout should succeed");
+
+    // The lock-file pin records the explicit LFS request so reinstalls
+    // re-validate LFS objects (`db.contains_lfs_artifacts` in `GitSource`).
+    match checkout.pinned {
+        PinnedSourceSpec::Git(pinned) => {
+            assert_eq!(pinned.source.lfs, Some(true));
+        }
+        other => panic!("expected git pinned spec, got {other:?}"),
+    }
+
+    // `data.bin` should be the real blob — not still a git-lfs pointer file.
+    let data = checkout.path.join("data.bin");
+    let contents = fs_err::read_to_string(data.as_std_path()).unwrap_or_default();
+    assert!(
+        !contents.starts_with("version https://git-lfs.github.com/spec/"),
+        "data.bin should be materialised, not a pointer file"
+    );
+}
+
 /// One git checkout fires the full reporter sequence. The
 /// [`LifecycleReporter`] asserts ordering and exactly-once internally;
 /// the test just asserts the run reached the terminal state.
@@ -76,6 +131,7 @@ async fn git_checkout_fires_full_reporter_lifecycle() {
                 git: repo.base_url.clone(),
                 rev: None,
                 subdirectory: Subdirectory::default(),
+                lfs: None,
             })
             .await
         })

--- a/crates/pixi_compute_sources/tests/git_checkout.rs
+++ b/crates/pixi_compute_sources/tests/git_checkout.rs
@@ -30,7 +30,7 @@ async fn pin_and_checkout_git_default_branch() {
         git: repo.base_url.clone(),
         rev: None,
         subdirectory: Subdirectory::default(),
-        lfs: None,
+        lfs: GitLfs::Disabled,
     };
 
     let checkout = engine
@@ -85,7 +85,7 @@ async fn pin_and_checkout_git_with_lfs() {
         git: repo.base_url.clone(),
         rev: None,
         subdirectory: Subdirectory::default(),
-        lfs: Some(GitLfs::Enabled),
+        lfs: GitLfs::Enabled,
     };
 
     let checkout = engine
@@ -98,7 +98,7 @@ async fn pin_and_checkout_git_with_lfs() {
     // re-validate LFS objects (`db.contains_lfs_artifacts` in `GitSource`).
     match checkout.pinned {
         PinnedSourceSpec::Git(pinned) => {
-            assert_eq!(pinned.source.lfs, Some(GitLfs::Enabled));
+            assert_eq!(pinned.source.lfs, GitLfs::Enabled);
         }
         other => panic!("expected git pinned spec, got {other:?}"),
     }
@@ -132,7 +132,7 @@ async fn git_checkout_fires_full_reporter_lifecycle() {
                 git: repo.base_url.clone(),
                 rev: None,
                 subdirectory: Subdirectory::default(),
-                lfs: None,
+                lfs: GitLfs::Disabled,
             })
             .await
         })

--- a/crates/pixi_compute_sources/tests/git_checkout.rs
+++ b/crates/pixi_compute_sources/tests/git_checkout.rs
@@ -8,6 +8,7 @@ mod common;
 
 use common::{EngineConfig, LifecycleReporter, build_test_engine};
 use pixi_compute_sources::GitSourceCheckoutExt;
+use pixi_git::GitLfs;
 use pixi_record::PinnedSourceSpec;
 use pixi_spec::{GitSpec, Subdirectory};
 use pixi_test_utils::GitRepoFixture;
@@ -84,7 +85,7 @@ async fn pin_and_checkout_git_with_lfs() {
         git: repo.base_url.clone(),
         rev: None,
         subdirectory: Subdirectory::default(),
-        lfs: Some(true),
+        lfs: Some(GitLfs::Enabled),
     };
 
     let checkout = engine
@@ -97,7 +98,7 @@ async fn pin_and_checkout_git_with_lfs() {
     // re-validate LFS objects (`db.contains_lfs_artifacts` in `GitSource`).
     match checkout.pinned {
         PinnedSourceSpec::Git(pinned) => {
-            assert_eq!(pinned.source.lfs, Some(true));
+            assert_eq!(pinned.source.lfs, Some(GitLfs::Enabled));
         }
         other => panic!("expected git pinned spec, got {other:?}"),
     }

--- a/crates/pixi_core/src/lock_file/resolve/pypi.rs
+++ b/crates/pixi_core/src/lock_file/resolve/pypi.rs
@@ -369,6 +369,20 @@ pub async fn resolve_pypi(
         })
         .collect();
 
+    // Same idea as `original_git_references`, but for the `lfs` flag: uv doesn't
+    // know it, so we shuttle it from the manifest into the lock file ourselves.
+    let original_git_lfs: HashMap<_, _> = dependencies
+        .iter()
+        .filter_map(|(name, specs)| {
+            specs.iter().find_map(|spec| {
+                spec.source
+                    .as_git()
+                    .and_then(|git_spec| git_spec.lfs)
+                    .map(|lfs| (name.clone(), lfs))
+            })
+        })
+        .collect();
+
     // Pre-populate the git resolver with locked git references.
     // This ensures that when uv resolves git dependencies, it will find the cached commit
     // and not panic in `url_to_precise` function.
@@ -838,6 +852,7 @@ pub async fn resolve_pypi(
             context.concurrency.downloads_semaphore.clone(),
             project_root,
             &original_git_references,
+            &original_git_lfs,
         )
         .await
         .map_err(|e| SolveError::Locking(e.into()))?;
@@ -1002,6 +1017,7 @@ async fn lock_pypi_packages(
     downloads_semaphore: Arc<tokio::sync::Semaphore>,
     abs_project_root: &Path,
     original_git_references: &HashMap<uv_normalize::PackageName, pixi_spec::GitReference>,
+    original_git_lfs: &HashMap<uv_normalize::PackageName, bool>,
 ) -> miette::Result<LockedPypiRecords> {
     let mut locked_packages = Vec::with_capacity(resolution.len());
     let database =
@@ -1194,10 +1210,11 @@ async fn lock_pypi_packages(
                             let package_name = git.name.clone();
                             let original_reference =
                                 original_git_references.get(&package_name).cloned();
+                            let original_lfs = original_git_lfs.get(&package_name).copied();
 
                             // convert resolved source dist into a pinned git spec
                             let pinned_git_spec =
-                                into_pinned_git_spec(git.clone(), original_reference);
+                                into_pinned_git_spec(git.clone(), original_reference, original_lfs);
                             locked_packages.push(wheel(
                                 metadata,
                                 pinned_git_spec.into_locked_git_url().to_url().into(),

--- a/crates/pixi_core/src/lock_file/resolve/pypi.rs
+++ b/crates/pixi_core/src/lock_file/resolve/pypi.rs
@@ -369,16 +369,20 @@ pub async fn resolve_pypi(
         })
         .collect();
 
-    // Same idea as `original_git_references`, but for the `lfs` flag: uv doesn't
-    // know it, so we shuttle it from the manifest into the lock file ourselves.
+    // Same idea as `original_git_references`, but for the `lfs` flag: uv
+    // doesn't know it (it has its own `UV_GIT_LFS` env var), so we shuttle
+    // the manifest-side concrete policy into the lock file ourselves. Only
+    // `Enabled` entries make it into the map — the `into_pinned_git_spec`
+    // lookup defaults to `Disabled` when missing.
     let original_git_lfs: HashMap<_, _> = dependencies
         .iter()
         .filter_map(|(name, specs)| {
             specs.iter().find_map(|spec| {
-                spec.source
-                    .as_git()
-                    .and_then(|git_spec| git_spec.lfs)
-                    .map(|lfs| (name.clone(), lfs))
+                let git_spec = spec.source.as_git()?;
+                git_spec
+                    .lfs
+                    .is_enabled()
+                    .then(|| (name.clone(), git_spec.lfs))
             })
         })
         .collect();
@@ -1210,7 +1214,10 @@ async fn lock_pypi_packages(
                             let package_name = git.name.clone();
                             let original_reference =
                                 original_git_references.get(&package_name).cloned();
-                            let original_lfs = original_git_lfs.get(&package_name).copied();
+                            let original_lfs = original_git_lfs
+                                .get(&package_name)
+                                .copied()
+                                .unwrap_or(pixi_git::GitLfs::Disabled);
 
                             // convert resolved source dist into a pinned git spec
                             let pinned_git_spec =

--- a/crates/pixi_core/src/lock_file/resolve/pypi.rs
+++ b/crates/pixi_core/src/lock_file/resolve/pypi.rs
@@ -1017,7 +1017,7 @@ async fn lock_pypi_packages(
     downloads_semaphore: Arc<tokio::sync::Semaphore>,
     abs_project_root: &Path,
     original_git_references: &HashMap<uv_normalize::PackageName, pixi_spec::GitReference>,
-    original_git_lfs: &HashMap<uv_normalize::PackageName, bool>,
+    original_git_lfs: &HashMap<uv_normalize::PackageName, pixi_git::GitLfs>,
 ) -> miette::Result<LockedPypiRecords> {
     let mut locked_packages = Vec::with_capacity(resolution.len());
     let database =

--- a/crates/pixi_git/src/git.rs
+++ b/crates/pixi_git/src/git.rs
@@ -17,7 +17,7 @@ use std::{
 use url::Url;
 
 use crate::{
-    GitError,
+    GitError, GitLfs,
     sha::{GitOid, GitSha},
 };
 
@@ -45,19 +45,20 @@ pub static GIT: LazyLock<Result<PathBuf, GitBinaryError>> = LazyLock::new(|| {
 });
 
 /// Cached `git lfs` invoker. Probes `git lfs version` once; on success
-/// callers get a `GitLfs` whose [`GitLfs::cmd`] returns a fresh `Command`
-/// pre-set to `git lfs ...` with the terminal prompt disabled. Mirrors uv's
-/// `GIT_LFS` static.
-pub static GIT_LFS: LazyLock<Result<GitLfs, GitBinaryError>> = LazyLock::new(GitLfs::probe);
+/// callers get a [`GitLfsBin`] whose [`GitLfsBin::cmd`] returns a fresh
+/// `Command` pre-set to `git lfs ...` with the terminal prompt disabled.
+/// Mirrors uv's `GIT_LFS` static.
+pub static GIT_LFS: LazyLock<Result<GitLfsBin, GitBinaryError>> = LazyLock::new(GitLfsBin::probe);
 
 /// Pre-configured `git lfs` command builder. Kept opaque so the git path is
-/// resolved exactly once.
+/// resolved exactly once. Distinct from the policy enum [`crate::GitLfs`],
+/// which says *whether* to fetch LFS; this type says *how* to invoke it.
 #[derive(Debug, Clone)]
-pub struct GitLfs {
+pub struct GitLfsBin {
     git: PathBuf,
 }
 
-impl GitLfs {
+impl GitLfsBin {
     fn probe() -> Result<Self, GitBinaryError> {
         let git = GIT.as_ref().map_err(|e| e.clone())?.clone();
         let ok = Command::new(&git)
@@ -82,9 +83,9 @@ impl GitLfs {
 }
 
 /// Value for `GIT_LFS_SKIP_SMUDGE`, or `None` to leave the var unset.
-/// `Some(true)` → "0" (run smudge), `Some(false)` → "1" (skip smudge).
-fn lfs_skip_smudge_env(lfs: Option<bool>) -> Option<&'static str> {
-    lfs.map(|on| if on { "0" } else { "1" })
+/// `Enabled` → "0" (run smudge), `Disabled` → "1" (skip smudge).
+fn lfs_skip_smudge_env(lfs: Option<GitLfs>) -> Option<&'static str> {
+    lfs.map(|policy| if policy.is_enabled() { "0" } else { "1" })
 }
 
 /// Strategy when fetching refspecs for a [`GitReference`]
@@ -268,7 +269,7 @@ impl GitRemote {
         reference: &GitReference,
         locked_rev: Option<GitOid>,
         client: &LazyClient,
-        lfs: Option<bool>,
+        lfs: Option<GitLfs>,
     ) -> Result<(GitDatabase, GitOid), GitError> {
         let locked_ref = locked_rev.map(|oid| GitReference::FullCommit(oid.to_string()));
         let reference = locked_ref.as_ref().unwrap_or(reference);
@@ -281,7 +282,7 @@ impl GitRemote {
             };
 
             if let Some(rev) = resolved_commit_hash {
-                let ready = (lfs == Some(true))
+                let ready = (lfs == Some(GitLfs::Enabled))
                     .then(|| maybe_fetch_lfs(&mut db.repo, self.url.as_str(), rev))
                     .flatten();
                 return Ok((db.with_lfs_ready(ready), rev));
@@ -301,7 +302,7 @@ impl GitRemote {
             None => reference.resolve(&repo)?,
         };
 
-        let ready = (lfs == Some(true))
+        let ready = (lfs == Some(GitLfs::Enabled))
             .then(|| maybe_fetch_lfs(&mut repo, self.url.as_str(), rev))
             .flatten();
 
@@ -365,7 +366,7 @@ impl GitDatabase {
         &self,
         rev: GitOid,
         destination: &Path,
-        lfs: Option<bool>,
+        lfs: Option<GitLfs>,
     ) -> Result<GitCheckout, GitError> {
         // If the existing checkout exists, and it is fresh, use it.
         // A non-fresh checkout can happen if the checkout operation was
@@ -510,7 +511,7 @@ impl GitCheckout {
         into: &Path,
         database: &GitDatabase,
         revision: GitOid,
-        lfs: Option<bool>,
+        lfs: Option<GitLfs>,
     ) -> Result<Self, GitError> {
         tracing::debug!("cloning into {:?} from {:?}", database.repo.path, into);
         let dirname = into.parent().expect("into path must have a parent");
@@ -564,7 +565,7 @@ impl GitCheckout {
     /// *doesn't* exist, and then once we're done we create the file.
     ///
     /// [`.ok`]: CHECKOUT_READY_LOCK
-    fn reset(&self, lfs: Option<bool>) -> Result<(), GitError> {
+    fn reset(&self, lfs: Option<GitLfs>) -> Result<(), GitError> {
         let ok_file = self.repo.path.join(CHECKOUT_READY_LOCK);
         let _ = fs_err::remove_file(&ok_file);
 
@@ -769,7 +770,7 @@ fn maybe_fetch_lfs(repo: &mut GitRepository, url: &str, revision: GitOid) -> Opt
 /// `Ok` is `true` if fsck passes. `GIT_LFS_SKIP_SMUDGE` is removed from the
 /// env so an inherited value can't suppress smudge mid-fetch.
 fn fetch_lfs(
-    lfs: &GitLfs,
+    lfs: &GitLfsBin,
     repo: &mut GitRepository,
     url: &str,
     revision: GitOid,

--- a/crates/pixi_git/src/git.rs
+++ b/crates/pixi_git/src/git.rs
@@ -82,10 +82,12 @@ impl GitLfsBin {
     }
 }
 
-/// Value for `GIT_LFS_SKIP_SMUDGE`, or `None` to leave the var unset.
-/// `Enabled` → "0" (run smudge), `Disabled` → "1" (skip smudge).
-fn lfs_skip_smudge_env(lfs: Option<GitLfs>) -> Option<&'static str> {
-    lfs.map(|policy| if policy.is_enabled() { "0" } else { "1" })
+/// Value for `GIT_LFS_SKIP_SMUDGE`. Always set: `Enabled` → "0" (run
+/// smudge), `Disabled` → "1" (skip smudge). Mirrors uv's `reset()`, which
+/// always overrides the inherited env to avoid surprising smudge-filter
+/// behaviour from a leaky parent env.
+fn lfs_skip_smudge_env(lfs: GitLfs) -> &'static str {
+    if lfs.is_enabled() { "0" } else { "1" }
 }
 
 /// Strategy when fetching refspecs for a [`GitReference`]
@@ -269,7 +271,7 @@ impl GitRemote {
         reference: &GitReference,
         locked_rev: Option<GitOid>,
         client: &LazyClient,
-        lfs: Option<GitLfs>,
+        lfs: GitLfs,
     ) -> Result<(GitDatabase, GitOid), GitError> {
         let locked_ref = locked_rev.map(|oid| GitReference::FullCommit(oid.to_string()));
         let reference = locked_ref.as_ref().unwrap_or(reference);
@@ -282,7 +284,8 @@ impl GitRemote {
             };
 
             if let Some(rev) = resolved_commit_hash {
-                let ready = (lfs == Some(GitLfs::Enabled))
+                let ready = lfs
+                    .is_enabled()
                     .then(|| maybe_fetch_lfs(&mut db.repo, self.url.as_str(), rev))
                     .flatten();
                 return Ok((db.with_lfs_ready(ready), rev));
@@ -302,7 +305,8 @@ impl GitRemote {
             None => reference.resolve(&repo)?,
         };
 
-        let ready = (lfs == Some(GitLfs::Enabled))
+        let ready = lfs
+            .is_enabled()
             .then(|| maybe_fetch_lfs(&mut repo, self.url.as_str(), rev))
             .flatten();
 
@@ -366,7 +370,7 @@ impl GitDatabase {
         &self,
         rev: GitOid,
         destination: &Path,
-        lfs: Option<GitLfs>,
+        lfs: GitLfs,
     ) -> Result<GitCheckout, GitError> {
         // If the existing checkout exists, and it is fresh, use it.
         // A non-fresh checkout can happen if the checkout operation was
@@ -511,7 +515,7 @@ impl GitCheckout {
         into: &Path,
         database: &GitDatabase,
         revision: GitOid,
-        lfs: Option<GitLfs>,
+        lfs: GitLfs,
     ) -> Result<Self, GitError> {
         tracing::debug!("cloning into {:?} from {:?}", database.repo.path, into);
         let dirname = into.parent().expect("into path must have a parent");
@@ -565,7 +569,7 @@ impl GitCheckout {
     /// *doesn't* exist, and then once we're done we create the file.
     ///
     /// [`.ok`]: CHECKOUT_READY_LOCK
-    fn reset(&self, lfs: Option<GitLfs>) -> Result<(), GitError> {
+    fn reset(&self, lfs: GitLfs) -> Result<(), GitError> {
         let ok_file = self.repo.path.join(CHECKOUT_READY_LOCK);
         let _ = fs_err::remove_file(&ok_file);
 
@@ -579,10 +583,8 @@ impl GitCheckout {
             .arg("reset")
             .arg("--hard")
             .arg(self.revision.as_str())
-            .current_dir(&self.repo.path);
-        if let Some(value) = skip_smudge {
-            reset_cmd.env(GIT_LFS_SKIP_SMUDGE, value);
-        }
+            .current_dir(&self.repo.path)
+            .env(GIT_LFS_SKIP_SMUDGE, skip_smudge);
         reset_cmd.output()?;
 
         // Update submodules (`git submodule update --recursive`).
@@ -592,10 +594,8 @@ impl GitCheckout {
             .arg("update")
             .arg("--recursive")
             .arg("--init")
-            .current_dir(&self.repo.path);
-        if let Some(value) = skip_smudge {
-            submodule_cmd.env(GIT_LFS_SKIP_SMUDGE, value);
-        }
+            .current_dir(&self.repo.path)
+            .env(GIT_LFS_SKIP_SMUDGE, skip_smudge);
         submodule_cmd.output().map(drop)?;
 
         fs_err::File::create(ok_file)?;

--- a/crates/pixi_git/src/lfs.rs
+++ b/crates/pixi_git/src/lfs.rs
@@ -1,0 +1,143 @@
+//! [`GitLfs`] preference: whether a git checkout should also fetch git-LFS
+//! objects. Mirrors `uv_git_types::GitLfs`'s two-variant shape; pixi keeps
+//! the "no opinion" state at the call site as `Option<GitLfs>` so the env
+//! var (`PIXI_GIT_LFS`) can act as a global default.
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// The environment variable consulted by [`GitLfs::from_env`].
+pub const PIXI_GIT_LFS_ENV: &str = "PIXI_GIT_LFS";
+
+/// Whether to fetch git-LFS objects when checking out a repository.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum GitLfs {
+    /// Run `git lfs fetch` / `git lfs fsck` and let smudge filters
+    /// materialise pointer files.
+    Enabled,
+    /// Force-skip the smudge filter; pointer files stay as pointers.
+    Disabled,
+}
+
+impl GitLfs {
+    /// Parse [`PIXI_GIT_LFS_ENV`]. Accepts `1`/`0`, `true`/`false`,
+    /// `yes`/`no`, `on`/`off` (case-insensitive). Unset / empty → `None`;
+    /// unrecognised values are treated as `Enabled` with a tracing warning
+    /// (back-compat with the env-only landing in #6183).
+    pub fn from_env() -> Option<Self> {
+        let raw = std::env::var(PIXI_GIT_LFS_ENV).ok()?;
+        let value = raw.trim();
+        if value.is_empty() {
+            return None;
+        }
+        if value == "0"
+            || value.eq_ignore_ascii_case("false")
+            || value.eq_ignore_ascii_case("no")
+            || value.eq_ignore_ascii_case("off")
+        {
+            return Some(Self::Disabled);
+        }
+        if value == "1"
+            || value.eq_ignore_ascii_case("true")
+            || value.eq_ignore_ascii_case("yes")
+            || value.eq_ignore_ascii_case("on")
+        {
+            return Some(Self::Enabled);
+        }
+        tracing::warn!("unrecognised value for {PIXI_GIT_LFS_ENV}: {raw:?}; treating as enabled");
+        Some(Self::Enabled)
+    }
+
+    /// `true` for [`GitLfs::Enabled`].
+    pub fn is_enabled(self) -> bool {
+        matches!(self, Self::Enabled)
+    }
+}
+
+impl From<bool> for GitLfs {
+    fn from(b: bool) -> Self {
+        if b { Self::Enabled } else { Self::Disabled }
+    }
+}
+
+impl From<GitLfs> for bool {
+    fn from(lfs: GitLfs) -> Self {
+        lfs.is_enabled()
+    }
+}
+
+// Round-trip through serde as a bool. The manifest already writes
+// `lfs = true/false` and the locked URL writes `?lfs=true|false`; keeping
+// the serde shape as `bool` avoids re-formatting either.
+impl Serialize for GitLfs {
+    fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        ser.serialize_bool(self.is_enabled())
+    }
+}
+
+impl<'de> Deserialize<'de> for GitLfs {
+    fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        bool::deserialize(de).map(GitLfs::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bool_roundtrip() {
+        assert_eq!(GitLfs::from(true), GitLfs::Enabled);
+        assert_eq!(GitLfs::from(false), GitLfs::Disabled);
+        assert!(GitLfs::Enabled.is_enabled());
+        assert!(!GitLfs::Disabled.is_enabled());
+    }
+
+    /// Serialised env-var swap to keep parallel tests from racing on
+    /// the process-global env.
+    fn with_env<R>(value: Option<&str>, body: impl FnOnce() -> R) -> R {
+        use std::sync::Mutex;
+        static LOCK: Mutex<()> = Mutex::new(());
+        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let previous = std::env::var(PIXI_GIT_LFS_ENV).ok();
+        // SAFETY: tests are serialised by LOCK above.
+        match value {
+            Some(v) => unsafe { std::env::set_var(PIXI_GIT_LFS_ENV, v) },
+            None => unsafe { std::env::remove_var(PIXI_GIT_LFS_ENV) },
+        }
+        let out = body();
+        match previous {
+            Some(v) => unsafe { std::env::set_var(PIXI_GIT_LFS_ENV, v) },
+            None => unsafe { std::env::remove_var(PIXI_GIT_LFS_ENV) },
+        }
+        out
+    }
+
+    #[test]
+    fn env_unset_is_none() {
+        with_env(None, || assert_eq!(GitLfs::from_env(), None));
+    }
+
+    #[test]
+    fn env_empty_is_none() {
+        with_env(Some(""), || assert_eq!(GitLfs::from_env(), None));
+        with_env(Some("   "), || assert_eq!(GitLfs::from_env(), None));
+    }
+
+    #[test]
+    fn env_truthy_is_enabled() {
+        for v in ["1", "true", "TRUE", "yes", "YES", "on", "ON"] {
+            with_env(Some(v), || {
+                assert_eq!(GitLfs::from_env(), Some(GitLfs::Enabled), "value={v}")
+            });
+        }
+    }
+
+    #[test]
+    fn env_falsy_is_disabled() {
+        for v in ["0", "false", "FALSE", "no", "NO", "off", "OFF"] {
+            with_env(Some(v), || {
+                assert_eq!(GitLfs::from_env(), Some(GitLfs::Disabled), "value={v}")
+            });
+        }
+    }
+}

--- a/crates/pixi_git/src/lfs.rs
+++ b/crates/pixi_git/src/lfs.rs
@@ -1,7 +1,8 @@
 //! [`GitLfs`] preference: whether a git checkout should also fetch git-LFS
-//! objects. Mirrors `uv_git_types::GitLfs`'s two-variant shape; pixi keeps
-//! the "no opinion" state at the call site as `Option<GitLfs>` so the env
-//! var (`PIXI_GIT_LFS`) can act as a global default.
+//! objects. Mirrors `uv_git_types::GitLfs`'s two-variant shape, with
+//! [`From<Option<bool>>`] as the single tri-state → binary boundary that
+//! consults the `PIXI_GIT_LFS` env var when the manifest is silent (the
+//! same pattern uv uses for `UV_GIT_LFS`).
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -9,42 +10,47 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 pub const PIXI_GIT_LFS_ENV: &str = "PIXI_GIT_LFS";
 
 /// Whether to fetch git-LFS objects when checking out a repository.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+/// Mirrors `uv_git_types::GitLfs`. Defaults to [`GitLfs::Disabled`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
 pub enum GitLfs {
+    /// Force-skip the smudge filter; pointer files stay as pointers.
+    #[default]
+    Disabled,
     /// Run `git lfs fetch` / `git lfs fsck` and let smudge filters
     /// materialise pointer files.
     Enabled,
-    /// Force-skip the smudge filter; pointer files stay as pointers.
-    Disabled,
 }
 
 impl GitLfs {
     /// Parse [`PIXI_GIT_LFS_ENV`]. Accepts `1`/`0`, `true`/`false`,
-    /// `yes`/`no`, `on`/`off` (case-insensitive). Unset / empty → `None`;
-    /// unrecognised values are treated as `Enabled` with a tracing warning
-    /// (back-compat with the env-only landing in #6183).
-    pub fn from_env() -> Option<Self> {
-        let raw = std::env::var(PIXI_GIT_LFS_ENV).ok()?;
+    /// `yes`/`no`, `on`/`off` (case-insensitive). Unset / empty / unset →
+    /// [`GitLfs::Disabled`]; unrecognised values are treated as `Enabled`
+    /// with a tracing warning (back-compat with the env-only landing in
+    /// #6183).
+    pub fn from_env() -> Self {
+        let Ok(raw) = std::env::var(PIXI_GIT_LFS_ENV) else {
+            return Self::Disabled;
+        };
         let value = raw.trim();
         if value.is_empty() {
-            return None;
+            return Self::Disabled;
         }
         if value == "0"
             || value.eq_ignore_ascii_case("false")
             || value.eq_ignore_ascii_case("no")
             || value.eq_ignore_ascii_case("off")
         {
-            return Some(Self::Disabled);
+            return Self::Disabled;
         }
         if value == "1"
             || value.eq_ignore_ascii_case("true")
             || value.eq_ignore_ascii_case("yes")
             || value.eq_ignore_ascii_case("on")
         {
-            return Some(Self::Enabled);
+            return Self::Enabled;
         }
         tracing::warn!("unrecognised value for {PIXI_GIT_LFS_ENV}: {raw:?}; treating as enabled");
-        Some(Self::Enabled)
+        Self::Enabled
     }
 
     /// `true` for [`GitLfs::Enabled`].
@@ -62,6 +68,20 @@ impl From<bool> for GitLfs {
 impl From<GitLfs> for bool {
     fn from(lfs: GitLfs) -> Self {
         lfs.is_enabled()
+    }
+}
+
+/// Resolve the manifest-input tri-state (`lfs = true/false` or absent) to
+/// a concrete policy, consulting [`GitLfs::from_env`] when absent. Mirrors
+/// uv's `From<Option<bool>> for GitLfs`. All internal pixi types store
+/// the resolved binary value; tri-state only lives at this boundary.
+impl From<Option<bool>> for GitLfs {
+    fn from(value: Option<bool>) -> Self {
+        match value {
+            Some(true) => Self::Enabled,
+            Some(false) => Self::Disabled,
+            None => Self::from_env(),
+        }
     }
 }
 
@@ -113,21 +133,25 @@ mod tests {
     }
 
     #[test]
-    fn env_unset_is_none() {
-        with_env(None, || assert_eq!(GitLfs::from_env(), None));
+    fn env_unset_is_disabled() {
+        with_env(None, || assert_eq!(GitLfs::from_env(), GitLfs::Disabled));
     }
 
     #[test]
-    fn env_empty_is_none() {
-        with_env(Some(""), || assert_eq!(GitLfs::from_env(), None));
-        with_env(Some("   "), || assert_eq!(GitLfs::from_env(), None));
+    fn env_empty_is_disabled() {
+        with_env(Some(""), || {
+            assert_eq!(GitLfs::from_env(), GitLfs::Disabled)
+        });
+        with_env(Some("   "), || {
+            assert_eq!(GitLfs::from_env(), GitLfs::Disabled)
+        });
     }
 
     #[test]
     fn env_truthy_is_enabled() {
         for v in ["1", "true", "TRUE", "yes", "YES", "on", "ON"] {
             with_env(Some(v), || {
-                assert_eq!(GitLfs::from_env(), Some(GitLfs::Enabled), "value={v}")
+                assert_eq!(GitLfs::from_env(), GitLfs::Enabled, "value={v}")
             });
         }
     }
@@ -136,8 +160,22 @@ mod tests {
     fn env_falsy_is_disabled() {
         for v in ["0", "false", "FALSE", "no", "NO", "off", "OFF"] {
             with_env(Some(v), || {
-                assert_eq!(GitLfs::from_env(), Some(GitLfs::Disabled), "value={v}")
+                assert_eq!(GitLfs::from_env(), GitLfs::Disabled, "value={v}")
             });
         }
+    }
+
+    /// `From<Option<bool>>` is the single tri-state → binary boundary,
+    /// matching uv. `Some(_)` is honoured verbatim, `None` consults env.
+    #[test]
+    fn from_option_bool_resolves_env() {
+        assert_eq!(GitLfs::from(Some(true)), GitLfs::Enabled);
+        assert_eq!(GitLfs::from(Some(false)), GitLfs::Disabled);
+        with_env(Some("1"), || {
+            assert_eq!(GitLfs::from(None::<bool>), GitLfs::Enabled);
+        });
+        with_env(None, || {
+            assert_eq!(GitLfs::from(None::<bool>), GitLfs::Disabled);
+        });
     }
 }

--- a/crates/pixi_git/src/lfs.rs
+++ b/crates/pixi_git/src/lfs.rs
@@ -1,13 +1,14 @@
 //! [`GitLfs`] preference: whether a git checkout should also fetch git-LFS
-//! objects. Mirrors `uv_git_types::GitLfs`'s two-variant shape, with
-//! [`From<Option<bool>>`] as the single tri-state → binary boundary that
-//! consults the `PIXI_GIT_LFS` env var when the manifest is silent (the
-//! same pattern uv uses for `UV_GIT_LFS`).
+//! objects. Mirrors `uv_git_types::GitLfs`'s two-variant shape.
+//!
+//! Unlike uv, pixi does **not** consult an environment variable: an
+//! unspecified `lfs` deterministically means [`GitLfs::Disabled`]. Letting
+//! the env decide would make the parsed manifest — and therefore the lock
+//! file — depend on ambient state, so the same `pixi.toml` could resolve
+//! differently on two machines. (uv's `UV_GIT_LFS` flows into its lock file
+//! this way; we deliberately avoid that.)
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
-/// The environment variable consulted by [`GitLfs::from_env`].
-pub const PIXI_GIT_LFS_ENV: &str = "PIXI_GIT_LFS";
 
 /// Whether to fetch git-LFS objects when checking out a repository.
 /// Mirrors `uv_git_types::GitLfs`. Defaults to [`GitLfs::Disabled`].
@@ -22,37 +23,6 @@ pub enum GitLfs {
 }
 
 impl GitLfs {
-    /// Parse [`PIXI_GIT_LFS_ENV`]. Accepts `1`/`0`, `true`/`false`,
-    /// `yes`/`no`, `on`/`off` (case-insensitive). Unset / empty / unset →
-    /// [`GitLfs::Disabled`]; unrecognised values are treated as `Enabled`
-    /// with a tracing warning (back-compat with the env-only landing in
-    /// #6183).
-    pub fn from_env() -> Self {
-        let Ok(raw) = std::env::var(PIXI_GIT_LFS_ENV) else {
-            return Self::Disabled;
-        };
-        let value = raw.trim();
-        if value.is_empty() {
-            return Self::Disabled;
-        }
-        if value == "0"
-            || value.eq_ignore_ascii_case("false")
-            || value.eq_ignore_ascii_case("no")
-            || value.eq_ignore_ascii_case("off")
-        {
-            return Self::Disabled;
-        }
-        if value == "1"
-            || value.eq_ignore_ascii_case("true")
-            || value.eq_ignore_ascii_case("yes")
-            || value.eq_ignore_ascii_case("on")
-        {
-            return Self::Enabled;
-        }
-        tracing::warn!("unrecognised value for {PIXI_GIT_LFS_ENV}: {raw:?}; treating as enabled");
-        Self::Enabled
-    }
-
     /// `true` for [`GitLfs::Enabled`].
     pub fn is_enabled(self) -> bool {
         matches!(self, Self::Enabled)
@@ -71,23 +41,22 @@ impl From<GitLfs> for bool {
     }
 }
 
-/// Resolve the manifest-input tri-state (`lfs = true/false` or absent) to
-/// a concrete policy, consulting [`GitLfs::from_env`] when absent. Mirrors
-/// uv's `From<Option<bool>> for GitLfs`. All internal pixi types store
-/// the resolved binary value; tri-state only lives at this boundary.
+/// Resolve the manifest-input tri-state (`lfs = true/false` or absent) to a
+/// concrete policy. Absence is [`GitLfs::Disabled`] — deterministic, no env
+/// lookup, so the parsed manifest and lock file are a pure function of the
+/// manifest text.
 impl From<Option<bool>> for GitLfs {
     fn from(value: Option<bool>) -> Self {
         match value {
             Some(true) => Self::Enabled,
-            Some(false) => Self::Disabled,
-            None => Self::from_env(),
+            Some(false) | None => Self::Disabled,
         }
     }
 }
 
-// Round-trip through serde as a bool. The manifest already writes
-// `lfs = true/false` and the locked URL writes `?lfs=true|false`; keeping
-// the serde shape as `bool` avoids re-formatting either.
+// Round-trip through serde as a bool. The manifest writes `lfs = true` and
+// the locked URL writes `?lfs=true`; keeping the serde shape as `bool`
+// avoids re-formatting either.
 impl Serialize for GitLfs {
     fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
         ser.serialize_bool(self.is_enabled())
@@ -112,70 +81,13 @@ mod tests {
         assert!(!GitLfs::Disabled.is_enabled());
     }
 
-    /// Serialised env-var swap to keep parallel tests from racing on
-    /// the process-global env.
-    fn with_env<R>(value: Option<&str>, body: impl FnOnce() -> R) -> R {
-        use std::sync::Mutex;
-        static LOCK: Mutex<()> = Mutex::new(());
-        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let previous = std::env::var(PIXI_GIT_LFS_ENV).ok();
-        // SAFETY: tests are serialised by LOCK above.
-        match value {
-            Some(v) => unsafe { std::env::set_var(PIXI_GIT_LFS_ENV, v) },
-            None => unsafe { std::env::remove_var(PIXI_GIT_LFS_ENV) },
-        }
-        let out = body();
-        match previous {
-            Some(v) => unsafe { std::env::set_var(PIXI_GIT_LFS_ENV, v) },
-            None => unsafe { std::env::remove_var(PIXI_GIT_LFS_ENV) },
-        }
-        out
-    }
-
+    /// `From<Option<bool>>` is the single tri-state → binary boundary.
+    /// Absence is deterministically `Disabled` (no env lookup), so a given
+    /// manifest always resolves the same way.
     #[test]
-    fn env_unset_is_disabled() {
-        with_env(None, || assert_eq!(GitLfs::from_env(), GitLfs::Disabled));
-    }
-
-    #[test]
-    fn env_empty_is_disabled() {
-        with_env(Some(""), || {
-            assert_eq!(GitLfs::from_env(), GitLfs::Disabled)
-        });
-        with_env(Some("   "), || {
-            assert_eq!(GitLfs::from_env(), GitLfs::Disabled)
-        });
-    }
-
-    #[test]
-    fn env_truthy_is_enabled() {
-        for v in ["1", "true", "TRUE", "yes", "YES", "on", "ON"] {
-            with_env(Some(v), || {
-                assert_eq!(GitLfs::from_env(), GitLfs::Enabled, "value={v}")
-            });
-        }
-    }
-
-    #[test]
-    fn env_falsy_is_disabled() {
-        for v in ["0", "false", "FALSE", "no", "NO", "off", "OFF"] {
-            with_env(Some(v), || {
-                assert_eq!(GitLfs::from_env(), GitLfs::Disabled, "value={v}")
-            });
-        }
-    }
-
-    /// `From<Option<bool>>` is the single tri-state → binary boundary,
-    /// matching uv. `Some(_)` is honoured verbatim, `None` consults env.
-    #[test]
-    fn from_option_bool_resolves_env() {
+    fn from_option_bool_is_deterministic() {
         assert_eq!(GitLfs::from(Some(true)), GitLfs::Enabled);
         assert_eq!(GitLfs::from(Some(false)), GitLfs::Disabled);
-        with_env(Some("1"), || {
-            assert_eq!(GitLfs::from(None::<bool>), GitLfs::Enabled);
-        });
-        with_env(None, || {
-            assert_eq!(GitLfs::from(None::<bool>), GitLfs::Disabled);
-        });
+        assert_eq!(GitLfs::from(None::<bool>), GitLfs::Disabled);
     }
 }

--- a/crates/pixi_git/src/lib.rs
+++ b/crates/pixi_git/src/lib.rs
@@ -36,32 +36,37 @@ pub struct GitUrl {
     reference: GitReference,
     /// The precise commit to use, if known.
     precise: Option<GitSha>,
-    /// LFS preference for this URL. Mirrors uv's `GitUrl` design: `Some(_)`
-    /// is an explicit caller override, `None` defers to [`GitLfs::from_env`]
-    /// at fetch time. Part of `Hash`/`Eq` so two requests for the same
-    /// commit with different lfs preferences get distinct dedup keys.
-    lfs: Option<GitLfs>,
+    /// LFS preference for this URL. Always concrete (mirrors uv); the env
+    /// var fallback was resolved at the manifest-input boundary via
+    /// [`GitLfs::from`]`(Option<bool>)`. Part of `Hash`/`Eq` so two requests
+    /// for the same commit with different lfs preferences get distinct
+    /// dedup keys.
+    lfs: GitLfs,
 }
 
 impl GitUrl {
     /// Create a new [`GitUrl`] from a repository URL and a reference.
+    /// Defaults LFS to [`GitLfs::Disabled`]; call [`Self::with_lfs`] to
+    /// override.
     pub fn from_reference(repository: Url, reference: GitReference) -> Self {
         let precise = reference.as_sha();
         Self {
             repository,
             reference,
             precise,
-            lfs: None,
+            lfs: GitLfs::Disabled,
         }
     }
 
     /// Create a new [`GitUrl`] from a repository URL and a precise commit.
+    /// Defaults LFS to [`GitLfs::Disabled`]; call [`Self::with_lfs`] to
+    /// override.
     pub fn from_commit(repository: Url, reference: GitReference, precise: GitSha) -> Self {
         Self {
             repository,
             reference,
             precise: Some(precise),
-            lfs: None,
+            lfs: GitLfs::Disabled,
         }
     }
 
@@ -79,9 +84,9 @@ impl GitUrl {
         self
     }
 
-    /// Set the LFS preference. See [`GitUrl::lfs`] for tri-state semantics.
+    /// Set the LFS preference.
     #[must_use]
-    pub fn with_lfs(mut self, lfs: Option<GitLfs>) -> Self {
+    pub fn with_lfs(mut self, lfs: GitLfs) -> Self {
         self.lfs = lfs;
         self
     }
@@ -101,9 +106,8 @@ impl GitUrl {
         self.precise
     }
 
-    /// Return the LFS preference: `Some(_)` is an explicit override, `None`
-    /// defers to [`GitLfs::from_env`] at fetch time.
-    pub fn lfs(&self) -> Option<GitLfs> {
+    /// Return the LFS preference (already resolved at construction).
+    pub fn lfs(&self) -> GitLfs {
         self.lfs
     }
 }

--- a/crates/pixi_git/src/lib.rs
+++ b/crates/pixi_git/src/lib.rs
@@ -15,7 +15,7 @@ pub mod sha;
 pub mod source;
 pub mod url;
 
-pub use lfs::{GitLfs, PIXI_GIT_LFS_ENV};
+pub use lfs::GitLfs;
 
 /// The query parameter used to specify the type of reference in a Git URL.
 pub const GIT_URL_QUERY_REV_TYPE: &str = "rev_type";

--- a/crates/pixi_git/src/lib.rs
+++ b/crates/pixi_git/src/lib.rs
@@ -33,6 +33,12 @@ pub struct GitUrl {
     reference: GitReference,
     /// The precise commit to use, if known.
     precise: Option<GitSha>,
+    /// LFS preference for this URL. Mirrors uv's `GitUrl` design: `Some(true/false)`
+    /// is an explicit caller override, `None` defers to the `PIXI_GIT_LFS` env
+    /// var (resolved at fetch time by [`source::GitSource::new`]). Part of
+    /// `Hash`/`Eq` so two requests for the same commit with different lfs
+    /// preferences get distinct dedup keys.
+    lfs: Option<bool>,
 }
 
 impl GitUrl {
@@ -43,6 +49,7 @@ impl GitUrl {
             repository,
             reference,
             precise,
+            lfs: None,
         }
     }
 
@@ -52,6 +59,7 @@ impl GitUrl {
             repository,
             reference,
             precise: Some(precise),
+            lfs: None,
         }
     }
 
@@ -69,6 +77,13 @@ impl GitUrl {
         self
     }
 
+    /// Set the LFS preference. See [`GitUrl::lfs`] for tri-state semantics.
+    #[must_use]
+    pub fn with_lfs(mut self, lfs: Option<bool>) -> Self {
+        self.lfs = lfs;
+        self
+    }
+
     /// Return the [`Url`] of the Git repository.
     pub fn repository(&self) -> &Url {
         &self.repository
@@ -82,6 +97,12 @@ impl GitUrl {
     /// Return the precise commit, if known.
     pub fn precise(&self) -> Option<GitSha> {
         self.precise
+    }
+
+    /// Return the LFS preference: `Some(true)` / `Some(false)` is an explicit
+    /// override, `None` defers to the `PIXI_GIT_LFS` env var at fetch time.
+    pub fn lfs(&self) -> Option<bool> {
+        self.lfs
     }
 }
 

--- a/crates/pixi_git/src/lib.rs
+++ b/crates/pixi_git/src/lib.rs
@@ -9,10 +9,13 @@ use sha::{GitSha, OidParseError};
 
 pub mod credentials;
 pub mod git;
+pub mod lfs;
 pub mod resolver;
 pub mod sha;
 pub mod source;
 pub mod url;
+
+pub use lfs::{GitLfs, PIXI_GIT_LFS_ENV};
 
 /// The query parameter used to specify the type of reference in a Git URL.
 pub const GIT_URL_QUERY_REV_TYPE: &str = "rev_type";
@@ -33,12 +36,11 @@ pub struct GitUrl {
     reference: GitReference,
     /// The precise commit to use, if known.
     precise: Option<GitSha>,
-    /// LFS preference for this URL. Mirrors uv's `GitUrl` design: `Some(true/false)`
-    /// is an explicit caller override, `None` defers to the `PIXI_GIT_LFS` env
-    /// var (resolved at fetch time by [`source::GitSource::new`]). Part of
-    /// `Hash`/`Eq` so two requests for the same commit with different lfs
-    /// preferences get distinct dedup keys.
-    lfs: Option<bool>,
+    /// LFS preference for this URL. Mirrors uv's `GitUrl` design: `Some(_)`
+    /// is an explicit caller override, `None` defers to [`GitLfs::from_env`]
+    /// at fetch time. Part of `Hash`/`Eq` so two requests for the same
+    /// commit with different lfs preferences get distinct dedup keys.
+    lfs: Option<GitLfs>,
 }
 
 impl GitUrl {
@@ -79,7 +81,7 @@ impl GitUrl {
 
     /// Set the LFS preference. See [`GitUrl::lfs`] for tri-state semantics.
     #[must_use]
-    pub fn with_lfs(mut self, lfs: Option<bool>) -> Self {
+    pub fn with_lfs(mut self, lfs: Option<GitLfs>) -> Self {
         self.lfs = lfs;
         self
     }
@@ -99,9 +101,9 @@ impl GitUrl {
         self.precise
     }
 
-    /// Return the LFS preference: `Some(true)` / `Some(false)` is an explicit
-    /// override, `None` defers to the `PIXI_GIT_LFS` env var at fetch time.
-    pub fn lfs(&self) -> Option<bool> {
+    /// Return the LFS preference: `Some(_)` is an explicit override, `None`
+    /// defers to [`GitLfs::from_env`] at fetch time.
+    pub fn lfs(&self) -> Option<GitLfs> {
         self.lfs
     }
 }

--- a/crates/pixi_git/src/resolver.rs
+++ b/crates/pixi_git/src/resolver.rs
@@ -49,8 +49,7 @@ impl GitResolver {
     /// Fetch a remote Git repository.
     ///
     /// The LFS preference travels on the [`GitUrl`] itself (see
-    /// [`GitUrl::with_lfs`]); `GitSource::new` reads it and falls back to
-    /// the `PIXI_GIT_LFS` env var when unset.
+    /// [`GitUrl::with_lfs`]); `GitSource::new` reads it directly.
     pub async fn fetch(
         &self,
         url: GitUrl,

--- a/crates/pixi_git/src/resolver.rs
+++ b/crates/pixi_git/src/resolver.rs
@@ -48,16 +48,15 @@ impl GitResolver {
 
     /// Fetch a remote Git repository.
     ///
-    /// `lfs` overrides the env-var default (`PIXI_GIT_LFS`): `Some(true)` /
-    /// `Some(false)` is explicit, `None` defers to the env. See
-    /// [`GitSource::with_lfs`].
+    /// The LFS preference travels on the [`GitUrl`] itself (see
+    /// [`GitUrl::with_lfs`]); `GitSource::new` reads it and falls back to
+    /// the `PIXI_GIT_LFS` env var when unset.
     pub async fn fetch(
         &self,
         url: GitUrl,
         client: LazyClient,
         cache: PathBuf,
         reporter: Option<Arc<dyn Reporter>>,
-        lfs: Option<bool>,
     ) -> Result<Fetch, GitError> {
         debug!("Fetching source distribution from Git: {url}");
 
@@ -85,13 +84,7 @@ impl GitResolver {
         write_guard.begin().await?;
 
         // Fetch the Git repository.
-        let mut source = GitSource::new(url.clone(), client, cache);
-        // Caller-provided `lfs` overrides the env-var default `None` set by
-        // `GitSource::new`. Skip the call entirely for `None` so the env var
-        // still wins for callers that don't care.
-        if lfs.is_some() {
-            source = source.with_lfs(lfs);
-        }
+        let source = GitSource::new(url.clone(), client, cache);
         let source = if let Some(reporter) = reporter {
             source.with_reporter(reporter)
         } else {

--- a/crates/pixi_git/src/resolver.rs
+++ b/crates/pixi_git/src/resolver.rs
@@ -47,12 +47,17 @@ impl GitResolver {
     }
 
     /// Fetch a remote Git repository.
+    ///
+    /// `lfs` overrides the env-var default (`PIXI_GIT_LFS`): `Some(true)` /
+    /// `Some(false)` is explicit, `None` defers to the env. See
+    /// [`GitSource::with_lfs`].
     pub async fn fetch(
         &self,
         url: GitUrl,
         client: LazyClient,
         cache: PathBuf,
         reporter: Option<Arc<dyn Reporter>>,
+        lfs: Option<bool>,
     ) -> Result<Fetch, GitError> {
         debug!("Fetching source distribution from Git: {url}");
 
@@ -80,7 +85,13 @@ impl GitResolver {
         write_guard.begin().await?;
 
         // Fetch the Git repository.
-        let source = GitSource::new(url.clone(), client, cache);
+        let mut source = GitSource::new(url.clone(), client, cache);
+        // Caller-provided `lfs` overrides the env-var default `None` set by
+        // `GitSource::new`. Skip the call entirely for `None` so the env var
+        // still wins for callers that don't care.
+        if lfs.is_some() {
+            source = source.with_lfs(lfs);
+        }
         let source = if let Some(reporter) = reporter {
             source.with_reporter(reporter)
         } else {

--- a/crates/pixi_git/src/source.rs
+++ b/crates/pixi_git/src/source.rs
@@ -12,41 +12,13 @@ use std::{
 use tracing::instrument;
 
 use crate::{
-    GitError, GitUrl, Reporter,
+    GitError, GitLfs, GitUrl, Reporter,
     credentials::GIT_STORE,
     git::GitRemote,
     resolver::RepositoryReference,
     sha::{GitOid, GitSha},
     url::RepositoryUrl,
 };
-
-/// Tri-state default for LFS fetching. Accepts `1`/`0`, `true`/`false`,
-/// `yes`/`no`, `on`/`off` (case-insensitive). Unset/empty → `None`.
-pub const PIXI_GIT_LFS_ENV: &str = "PIXI_GIT_LFS";
-
-pub fn lfs_enabled_from_env() -> Option<bool> {
-    let raw = std::env::var(PIXI_GIT_LFS_ENV).ok()?;
-    let value = raw.trim();
-    if value.is_empty() {
-        return None;
-    }
-    if value == "0"
-        || value.eq_ignore_ascii_case("false")
-        || value.eq_ignore_ascii_case("no")
-        || value.eq_ignore_ascii_case("off")
-    {
-        return Some(false);
-    }
-    if value == "1"
-        || value.eq_ignore_ascii_case("true")
-        || value.eq_ignore_ascii_case("yes")
-        || value.eq_ignore_ascii_case("on")
-    {
-        return Some(true);
-    }
-    tracing::warn!("unrecognised value for {PIXI_GIT_LFS_ENV}: {raw:?}; treating as enabled");
-    Some(true)
-}
 
 /// A remote Git source that can be checked out locally.
 pub struct GitSource {
@@ -58,20 +30,20 @@ pub struct GitSource {
     cache: PathBuf,
     /// The reporter to use for this source.
     reporter: Option<Arc<dyn Reporter>>,
-    /// `Some(true)` = fetch LFS, `Some(false)` = skip + force-skip smudge,
-    /// `None` = no opinion (don't touch `GIT_LFS_SKIP_SMUDGE`).
-    lfs: Option<bool>,
+    /// `Some(Enabled)` = fetch LFS, `Some(Disabled)` = skip + force-skip
+    /// smudge, `None` = no opinion (don't touch `GIT_LFS_SKIP_SMUDGE`).
+    lfs: Option<GitLfs>,
 }
 
 impl GitSource {
     /// Initialize a new Git source.
     ///
-    /// LFS preference is read from [`GitUrl::lfs`]; if unset there, the
-    /// `PIXI_GIT_LFS` env var is consulted via [`lfs_enabled_from_env`].
-    /// Callers wanting an explicit override should set it on the [`GitUrl`]
-    /// before constructing the source, or use [`Self::with_lfs`].
+    /// LFS preference is read from [`GitUrl::lfs`]; if unset there,
+    /// [`GitLfs::from_env`] is consulted (`PIXI_GIT_LFS`). Callers wanting
+    /// an explicit override should set it on the [`GitUrl`] before
+    /// constructing the source, or use [`Self::with_lfs`].
     pub fn new(git: GitUrl, client: LazyClient, cache: impl Into<PathBuf>) -> Self {
-        let lfs = git.lfs().or_else(lfs_enabled_from_env);
+        let lfs = git.lfs().or_else(GitLfs::from_env);
         Self {
             git,
             client,
@@ -90,13 +62,12 @@ impl GitSource {
         }
     }
 
-    /// Override the LFS preference. See [`PIXI_GIT_LFS_ENV`] for tri-state semantics.
-    /// Prefer setting `lfs` on the [`GitUrl`] itself via
-    /// [`GitUrl::with_lfs`] so it travels through dedup keys; this builder is
-    /// kept for cases where you want to override the URL's preference at the
-    /// source level.
+    /// Override the LFS preference. Prefer setting `lfs` on the [`GitUrl`]
+    /// itself via [`GitUrl::with_lfs`] so it travels through dedup keys;
+    /// this builder is kept for cases where you want to override the URL's
+    /// preference at the source level.
     #[must_use]
-    pub fn with_lfs(self, lfs: Option<bool>) -> Self {
+    pub fn with_lfs(self, lfs: Option<GitLfs>) -> Self {
         Self { lfs, ..self }
     }
 
@@ -118,7 +89,7 @@ impl GitSource {
         };
 
         let remote = GitRemote::new(&remote);
-        let lfs_requested = self.lfs == Some(true);
+        let lfs_requested = self.lfs == Some(GitLfs::Enabled);
         let (db, actual_rev, task) = match (self.git.precise, remote.db_at(&db_path).ok()) {
             // Cache hit: the DB has the commit and, if LFS was requested,
             // its LFS objects validate. Skip the regular fetch + checkout.
@@ -244,57 +215,4 @@ pub fn cache_digest(url: &RepositoryUrl) -> String {
     url.hash(&mut hasher);
     let hash = hasher.finish();
     format!("{hash:x}")
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// Serialised env-var swap to keep parallel tests from racing.
-    fn with_env<R>(value: Option<&str>, body: impl FnOnce() -> R) -> R {
-        use std::sync::Mutex;
-        static LOCK: Mutex<()> = Mutex::new(());
-        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let previous = std::env::var(PIXI_GIT_LFS_ENV).ok();
-        // SAFETY: tests are serialised by LOCK above.
-        match value {
-            Some(v) => unsafe { std::env::set_var(PIXI_GIT_LFS_ENV, v) },
-            None => unsafe { std::env::remove_var(PIXI_GIT_LFS_ENV) },
-        }
-        let out = body();
-        match previous {
-            Some(v) => unsafe { std::env::set_var(PIXI_GIT_LFS_ENV, v) },
-            None => unsafe { std::env::remove_var(PIXI_GIT_LFS_ENV) },
-        }
-        out
-    }
-
-    #[test]
-    fn env_unset_is_none() {
-        with_env(None, || assert_eq!(lfs_enabled_from_env(), None));
-    }
-
-    #[test]
-    fn env_empty_is_none() {
-        with_env(Some(""), || assert_eq!(lfs_enabled_from_env(), None));
-        with_env(Some("   "), || assert_eq!(lfs_enabled_from_env(), None));
-    }
-
-    #[test]
-    fn env_truthy_is_some_true() {
-        for v in ["1", "true", "TRUE", "yes", "YES", "on", "ON"] {
-            with_env(Some(v), || {
-                assert_eq!(lfs_enabled_from_env(), Some(true), "value={v}")
-            });
-        }
-    }
-
-    #[test]
-    fn env_falsy_is_some_false() {
-        for v in ["0", "false", "FALSE", "no", "NO", "off", "OFF"] {
-            with_env(Some(v), || {
-                assert_eq!(lfs_enabled_from_env(), Some(false), "value={v}")
-            });
-        }
-    }
 }

--- a/crates/pixi_git/src/source.rs
+++ b/crates/pixi_git/src/source.rs
@@ -30,20 +30,17 @@ pub struct GitSource {
     cache: PathBuf,
     /// The reporter to use for this source.
     reporter: Option<Arc<dyn Reporter>>,
-    /// `Some(Enabled)` = fetch LFS, `Some(Disabled)` = skip + force-skip
-    /// smudge, `None` = no opinion (don't touch `GIT_LFS_SKIP_SMUDGE`).
-    lfs: Option<GitLfs>,
+    /// Concrete LFS policy. Defaults to whatever the [`GitUrl`] carries
+    /// (which itself was resolved at manifest-input time).
+    lfs: GitLfs,
 }
 
 impl GitSource {
-    /// Initialize a new Git source.
-    ///
-    /// LFS preference is read from [`GitUrl::lfs`]; if unset there,
-    /// [`GitLfs::from_env`] is consulted (`PIXI_GIT_LFS`). Callers wanting
-    /// an explicit override should set it on the [`GitUrl`] before
-    /// constructing the source, or use [`Self::with_lfs`].
+    /// Initialize a new Git source. LFS preference is read directly from
+    /// [`GitUrl::lfs`]; the env-var fallback already happened at the
+    /// manifest-input boundary via [`GitLfs::from`]`(Option<bool>)`.
     pub fn new(git: GitUrl, client: LazyClient, cache: impl Into<PathBuf>) -> Self {
-        let lfs = git.lfs().or_else(GitLfs::from_env);
+        let lfs = git.lfs();
         Self {
             git,
             client,
@@ -64,10 +61,10 @@ impl GitSource {
 
     /// Override the LFS preference. Prefer setting `lfs` on the [`GitUrl`]
     /// itself via [`GitUrl::with_lfs`] so it travels through dedup keys;
-    /// this builder is kept for cases where you want to override the URL's
-    /// preference at the source level.
+    /// this builder is kept for cases where you want to override at the
+    /// source level.
     #[must_use]
-    pub fn with_lfs(self, lfs: Option<GitLfs>) -> Self {
+    pub fn with_lfs(self, lfs: GitLfs) -> Self {
         Self { lfs, ..self }
     }
 
@@ -89,7 +86,7 @@ impl GitSource {
         };
 
         let remote = GitRemote::new(&remote);
-        let lfs_requested = self.lfs == Some(GitLfs::Enabled);
+        let lfs_requested = self.lfs.is_enabled();
         let (db, actual_rev, task) = match (self.git.precise, remote.db_at(&db_path).ok()) {
             // Cache hit: the DB has the commit and, if LFS was requested,
             // its LFS objects validate. Skip the regular fetch + checkout.

--- a/crates/pixi_git/src/source.rs
+++ b/crates/pixi_git/src/source.rs
@@ -65,13 +65,19 @@ pub struct GitSource {
 
 impl GitSource {
     /// Initialize a new Git source.
+    ///
+    /// LFS preference is read from [`GitUrl::lfs`]; if unset there, the
+    /// `PIXI_GIT_LFS` env var is consulted via [`lfs_enabled_from_env`].
+    /// Callers wanting an explicit override should set it on the [`GitUrl`]
+    /// before constructing the source, or use [`Self::with_lfs`].
     pub fn new(git: GitUrl, client: LazyClient, cache: impl Into<PathBuf>) -> Self {
+        let lfs = git.lfs().or_else(lfs_enabled_from_env);
         Self {
             git,
             client,
             cache: cache.into(),
             reporter: None,
-            lfs: lfs_enabled_from_env(),
+            lfs,
         }
     }
 
@@ -85,6 +91,10 @@ impl GitSource {
     }
 
     /// Override the LFS preference. See [`PIXI_GIT_LFS_ENV`] for tri-state semantics.
+    /// Prefer setting `lfs` on the [`GitUrl`] itself via
+    /// [`GitUrl::with_lfs`] so it travels through dedup keys; this builder is
+    /// kept for cases where you want to override the URL's preference at the
+    /// source level.
     #[must_use]
     pub fn with_lfs(self, lfs: Option<bool>) -> Self {
         Self { lfs, ..self }

--- a/crates/pixi_git/src/source.rs
+++ b/crates/pixi_git/src/source.rs
@@ -37,8 +37,8 @@ pub struct GitSource {
 
 impl GitSource {
     /// Initialize a new Git source. LFS preference is read directly from
-    /// [`GitUrl::lfs`]; the env-var fallback already happened at the
-    /// manifest-input boundary via [`GitLfs::from`]`(Option<bool>)`.
+    /// [`GitUrl::lfs`] (resolved from the manifest at the input boundary via
+    /// [`GitLfs::from`]`(Option<bool>)`).
     pub fn new(git: GitUrl, client: LazyClient, cache: impl Into<PathBuf>) -> Self {
         let lfs = git.lfs();
         Self {

--- a/crates/pixi_git/tests/lfs.rs
+++ b/crates/pixi_git/tests/lfs.rs
@@ -4,7 +4,7 @@
 
 use std::path::Path;
 
-use pixi_git::{GitUrl, sha::GitSha, source::GitSource};
+use pixi_git::{GitLfs, GitUrl, sha::GitSha, source::GitSource};
 use pixi_test_utils::GitRepoFixture;
 use rattler_networking::LazyClient;
 use reqwest_middleware::ClientWithMiddleware;
@@ -79,7 +79,7 @@ fn fetch_without_lfs_leaves_pointer() {
     // git-lfs has nothing to fetch from a brand-new clone, so files end up
     // as the pointer.
     let fetch = GitSource::new(git_url, panic_client(), cache.path())
-        .with_lfs(Some(false))
+        .with_lfs(Some(GitLfs::Disabled))
         .fetch()
         .expect("fetch should succeed");
 
@@ -106,7 +106,7 @@ fn fetch_with_lfs_materialises_blob() {
 
     let git_url = GitUrl::try_from(repo.base_url.clone()).unwrap();
     let fetch = GitSource::new(git_url, panic_client(), cache.path())
-        .with_lfs(Some(true))
+        .with_lfs(Some(GitLfs::Enabled))
         .fetch()
         .expect("fetch should succeed");
 
@@ -146,7 +146,7 @@ fn cached_fetch_with_lfs_artifacts_is_ready() {
         let url = GitUrl::try_from(repo.base_url.clone())
             .unwrap()
             .with_precise(head);
-        GitSource::new(url, panic_client(), cache.path()).with_lfs(Some(true))
+        GitSource::new(url, panic_client(), cache.path()).with_lfs(Some(GitLfs::Enabled))
     };
 
     // Warm the cache.

--- a/crates/pixi_git/tests/lfs.rs
+++ b/crates/pixi_git/tests/lfs.rs
@@ -79,7 +79,7 @@ fn fetch_without_lfs_leaves_pointer() {
     // git-lfs has nothing to fetch from a brand-new clone, so files end up
     // as the pointer.
     let fetch = GitSource::new(git_url, panic_client(), cache.path())
-        .with_lfs(Some(GitLfs::Disabled))
+        .with_lfs(GitLfs::Disabled)
         .fetch()
         .expect("fetch should succeed");
 
@@ -106,7 +106,7 @@ fn fetch_with_lfs_materialises_blob() {
 
     let git_url = GitUrl::try_from(repo.base_url.clone()).unwrap();
     let fetch = GitSource::new(git_url, panic_client(), cache.path())
-        .with_lfs(Some(GitLfs::Enabled))
+        .with_lfs(GitLfs::Enabled)
         .fetch()
         .expect("fetch should succeed");
 
@@ -146,7 +146,7 @@ fn cached_fetch_with_lfs_artifacts_is_ready() {
         let url = GitUrl::try_from(repo.base_url.clone())
             .unwrap()
             .with_precise(head);
-        GitSource::new(url, panic_client(), cache.path()).with_lfs(Some(GitLfs::Enabled))
+        GitSource::new(url, panic_client(), cache.path()).with_lfs(GitLfs::Enabled)
     };
 
     // Warm the cache.

--- a/crates/pixi_manifest/src/toml/package.rs
+++ b/crates/pixi_manifest/src/toml/package.rs
@@ -1414,6 +1414,7 @@ mod test {
             rev: None,
             tag: None,
             subdirectory: None,
+            lfs: None,
             md5: None,
             sha256: None,
         });

--- a/crates/pixi_pypi_spec/src/lib.rs
+++ b/crates/pixi_pypi_spec/src/lib.rs
@@ -353,6 +353,7 @@ mod tests {
                 git: Url::parse("https://github.com/example/repo").unwrap(),
                 rev: None,
                 subdirectory: Default::default(),
+                lfs: None,
             },
         });
         assert!(spec.is_source_dependency());
@@ -399,6 +400,7 @@ mod tests {
                     git: Url::parse("https://github.com/example/repo").unwrap(),
                     rev: None,
                     subdirectory: Default::default(),
+                    lfs: None,
                 },
             },
             vec![extra.clone()],
@@ -424,6 +426,7 @@ mod tests {
                     git: Url::parse("https://github.com/example/repo").unwrap(),
                     rev: None,
                     subdirectory: Default::default(),
+                    lfs: None,
                 },
             },
             vec![],
@@ -574,6 +577,7 @@ mod tests {
                     git: Url::parse("https://github.com/ecederstrand/exchangelib").unwrap(),
                     rev: Some(GitReference::DefaultBranch),
                     subdirectory: Default::default(),
+                    lfs: None,
                 },
             })
         );
@@ -589,6 +593,7 @@ mod tests {
                         "b283011c6df4a9e034baca9aea19aa8e5a70e3ab".to_string()
                     )),
                     subdirectory: Default::default(),
+                    lfs: None,
                 },
             })
         );
@@ -681,7 +686,8 @@ mod tests {
                 git: GitSpec {
                     git: Url::parse("ssh://git@github.com/python-attrs/attrs.git").unwrap(),
                     rev: Some(GitReference::Rev("main".to_string())),
-                    subdirectory: Default::default()
+                    subdirectory: Default::default(),
+                    lfs: None,
                 },
             })
         );
@@ -698,6 +704,7 @@ mod tests {
                     git: Url::parse("https://github.com/Deltares/Ribasim.git").unwrap(),
                     rev: Some(GitReference::DefaultBranch),
                     subdirectory: Subdirectory::try_from("python/ribasim").unwrap(),
+                    lfs: None,
                 },
             })
         );

--- a/crates/pixi_pypi_spec/src/lib.rs
+++ b/crates/pixi_pypi_spec/src/lib.rs
@@ -11,6 +11,7 @@ use std::{
 
 use pep440_rs::VersionSpecifiers;
 use pep508_rs::{ExtraName, MarkerTree};
+use pixi_git::GitLfs;
 use pixi_spec::{GitSpec, Subdirectory};
 use serde::Serialize;
 use thiserror::Error;
@@ -353,7 +354,7 @@ mod tests {
                 git: Url::parse("https://github.com/example/repo").unwrap(),
                 rev: None,
                 subdirectory: Default::default(),
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         });
         assert!(spec.is_source_dependency());
@@ -400,7 +401,7 @@ mod tests {
                     git: Url::parse("https://github.com/example/repo").unwrap(),
                     rev: None,
                     subdirectory: Default::default(),
-                    lfs: None,
+                    lfs: GitLfs::Disabled,
                 },
             },
             vec![extra.clone()],
@@ -426,7 +427,7 @@ mod tests {
                     git: Url::parse("https://github.com/example/repo").unwrap(),
                     rev: None,
                     subdirectory: Default::default(),
-                    lfs: None,
+                    lfs: GitLfs::Disabled,
                 },
             },
             vec![],
@@ -577,7 +578,7 @@ mod tests {
                     git: Url::parse("https://github.com/ecederstrand/exchangelib").unwrap(),
                     rev: Some(GitReference::DefaultBranch),
                     subdirectory: Default::default(),
-                    lfs: None,
+                    lfs: GitLfs::Disabled,
                 },
             })
         );
@@ -593,7 +594,7 @@ mod tests {
                         "b283011c6df4a9e034baca9aea19aa8e5a70e3ab".to_string()
                     )),
                     subdirectory: Default::default(),
-                    lfs: None,
+                    lfs: GitLfs::Disabled,
                 },
             })
         );
@@ -687,7 +688,7 @@ mod tests {
                     git: Url::parse("ssh://git@github.com/python-attrs/attrs.git").unwrap(),
                     rev: Some(GitReference::Rev("main".to_string())),
                     subdirectory: Default::default(),
-                    lfs: None,
+                    lfs: GitLfs::Disabled,
                 },
             })
         );
@@ -704,7 +705,7 @@ mod tests {
                     git: Url::parse("https://github.com/Deltares/Ribasim.git").unwrap(),
                     rev: Some(GitReference::DefaultBranch),
                     subdirectory: Subdirectory::try_from("python/ribasim").unwrap(),
-                    lfs: None,
+                    lfs: GitLfs::Disabled,
                 },
             })
         );

--- a/crates/pixi_pypi_spec/src/pep508.rs
+++ b/crates/pixi_pypi_spec/src/pep508.rs
@@ -31,6 +31,7 @@ impl TryFrom<pep508_rs::Requirement> for PixiPypiSpec {
                                     git: git_url.repository().clone(),
                                     rev: Some(git_url.reference().clone().into()),
                                     subdirectory,
+                                    lfs: None,
                                 };
 
                                 PixiPypiSpec::with_extras_and_markers(
@@ -78,6 +79,7 @@ impl TryFrom<pep508_rs::Requirement> for PixiPypiSpec {
                             git: git_url.repository().clone(),
                             rev: Some(git_url.reference().clone().into()),
                             subdirectory,
+                            lfs: None,
                         };
                         PixiPypiSpec::with_extras_and_markers(
                             PixiPypiSource::Git { git: git_spec },

--- a/crates/pixi_pypi_spec/src/pep508.rs
+++ b/crates/pixi_pypi_spec/src/pep508.rs
@@ -1,6 +1,6 @@
 use crate::utils::extract_directory_from_url;
 use crate::{Pep508ToPyPiRequirementError, PixiPypiSource, PixiPypiSpec, VersionOrStar};
-use pixi_git::GitUrl;
+use pixi_git::{GitLfs, GitUrl};
 use pixi_spec::{GitSpec, Verbatim};
 use std::path::Path;
 
@@ -31,7 +31,7 @@ impl TryFrom<pep508_rs::Requirement> for PixiPypiSpec {
                                     git: git_url.repository().clone(),
                                     rev: Some(git_url.reference().clone().into()),
                                     subdirectory,
-                                    lfs: None,
+                                    lfs: GitLfs::Disabled,
                                 };
 
                                 PixiPypiSpec::with_extras_and_markers(
@@ -79,7 +79,7 @@ impl TryFrom<pep508_rs::Requirement> for PixiPypiSpec {
                             git: git_url.repository().clone(),
                             rev: Some(git_url.reference().clone().into()),
                             subdirectory,
-                            lfs: None,
+                            lfs: GitLfs::Disabled,
                         };
                         PixiPypiSpec::with_extras_and_markers(
                             PixiPypiSource::Git { git: git_spec },

--- a/crates/pixi_pypi_spec/src/snapshots/pixi_pypi_spec__tests__deserialize_failing.snap
+++ b/crates/pixi_pypi_spec/src/snapshots/pixi_pypi_spec__tests__deserialize_failing.snap
@@ -3,7 +3,7 @@ source: crates/pixi_pypi_spec/src/lib.rs
 expression: "snapshot.into_iter().map(|Snapshot { input, result }|\nformat!(\"input: {input}\\nresult: {} \",\nresult.as_object().unwrap().get(\"error\").unwrap().as_str().unwrap())).join(\"\\n\")"
 ---
 input: pkg = { ver = "1.2.3" }
-result:   × Unexpected keys, expected only 'version', 'extras', 'path', 'editable', 'git', 'branch', 'tag', 'rev', 'url', 'subdirectory', 'index', 'env-markers'
+result:   × Unexpected keys, expected only 'version', 'extras', 'path', 'editable', 'git', 'branch', 'tag', 'rev', 'lfs', 'url', 'subdirectory', 'index', 'env-markers'
    ╭─[pixi.toml:1:9]
  1 │ pkg = { ver = "1.2.3" }
    ·         ─┬─
@@ -56,7 +56,7 @@ result:   × invalid port number
    ·                ───────────────────────────────────────────────
    ╰──── 
 input: pkg = { branch = "main", tag = "v1", rev = "123456"  }
-result:   × `branch`, `rev`, and `tag` are only valid when `git` is specified
+result:   × `branch`, `rev`, `tag`, and `lfs` are only valid when `git` is specified
    ╭─[pixi.toml:1:7]
  1 │ pkg = { branch = "main", tag = "v1", rev = "123456"  }
    ·       ────────────────────────────────────────────────

--- a/crates/pixi_pypi_spec/src/toml.rs
+++ b/crates/pixi_pypi_spec/src/toml.rs
@@ -163,7 +163,7 @@ impl RawPyPiRequirement {
                                 .map(pixi_spec::Subdirectory::try_from)
                                 .transpose()?
                                 .unwrap_or_default(),
-                            lfs: self.lfs,
+                            lfs: self.lfs.map(pixi_git::GitLfs::from),
                         },
                     },
                     self.extras,
@@ -388,7 +388,7 @@ impl From<PixiPypiSpec> for toml_edit::Value {
                 if let Some(lfs) = lfs {
                     table.insert(
                         "lfs",
-                        toml_edit::Value::Boolean(toml_edit::Formatted::new(*lfs)),
+                        toml_edit::Value::Boolean(toml_edit::Formatted::new(lfs.is_enabled())),
                     );
                 }
                 insert_extras(&mut table, extras);
@@ -442,6 +442,7 @@ mod test {
     use crate::{PixiPypiSource, PixiPypiSpec};
     use insta::assert_snapshot;
     use pep508_rs::ExtraName;
+    use pixi_git::GitLfs;
     use pixi_spec::{GitReference, GitSpec};
     use pixi_test_utils::format_parse_error;
     use pixi_toml::TomlIndexMap;
@@ -797,7 +798,7 @@ mod test {
                     git: Url::parse("https://test.url.git").unwrap(),
                     rev: None,
                     subdirectory: Default::default(),
-                    lfs: Some(true),
+                    lfs: Some(GitLfs::Enabled),
                 },
             })
         );
@@ -817,7 +818,7 @@ mod test {
                     git: Url::parse("https://test.url.git").unwrap(),
                     rev: Some(GitReference::Branch("main".to_string())),
                     subdirectory: Default::default(),
-                    lfs: Some(false),
+                    lfs: Some(GitLfs::Disabled),
                 },
             })
         );

--- a/crates/pixi_pypi_spec/src/toml.rs
+++ b/crates/pixi_pypi_spec/src/toml.rs
@@ -163,7 +163,7 @@ impl RawPyPiRequirement {
                                 .map(pixi_spec::Subdirectory::try_from)
                                 .transpose()?
                                 .unwrap_or_default(),
-                            lfs: self.lfs.map(pixi_git::GitLfs::from),
+                            lfs: pixi_git::GitLfs::from(self.lfs),
                         },
                     },
                     self.extras,
@@ -385,10 +385,12 @@ impl From<PixiPypiSpec> for toml_edit::Value {
                         )),
                     );
                 }
-                if let Some(lfs) = lfs {
+                // Only emit `lfs = true` (mirrors uv's lockfile pattern).
+                // Absence is treated as Disabled by the parser.
+                if lfs.is_enabled() {
                     table.insert(
                         "lfs",
-                        toml_edit::Value::Boolean(toml_edit::Formatted::new(lfs.is_enabled())),
+                        toml_edit::Value::Boolean(toml_edit::Formatted::new(true)),
                     );
                 }
                 insert_extras(&mut table, extras);
@@ -698,7 +700,7 @@ mod test {
                     git: Url::parse("https://test.url.git").unwrap(),
                     rev: None,
                     subdirectory: Default::default(),
-                    lfs: None,
+                    lfs: GitLfs::Disabled,
                 },
             })
         );
@@ -718,7 +720,7 @@ mod test {
                     git: Url::parse("https://test.url.git").unwrap(),
                     rev: Some(GitReference::Branch("main".to_string())),
                     subdirectory: Default::default(),
-                    lfs: None,
+                    lfs: GitLfs::Disabled,
                 },
             })
         );
@@ -738,7 +740,7 @@ mod test {
                     git: Url::parse("https://test.url.git").unwrap(),
                     rev: Some(GitReference::Tag("v.1.2.3".to_string())),
                     subdirectory: Default::default(),
-                    lfs: None,
+                    lfs: GitLfs::Disabled,
                 },
             })
         );
@@ -758,7 +760,7 @@ mod test {
                     git: Url::parse("https://github.com/pallets/flask.git").unwrap(),
                     rev: Some(GitReference::Tag("3.0.0".to_string())),
                     subdirectory: Default::default(),
-                    lfs: None,
+                    lfs: GitLfs::Disabled,
                 },
             }),
         );
@@ -778,7 +780,7 @@ mod test {
                     git: Url::parse("https://test.url.git").unwrap(),
                     rev: Some(GitReference::Rev("123456".to_string())),
                     subdirectory: Default::default(),
-                    lfs: None,
+                    lfs: GitLfs::Disabled,
                 },
             })
         );
@@ -798,7 +800,7 @@ mod test {
                     git: Url::parse("https://test.url.git").unwrap(),
                     rev: None,
                     subdirectory: Default::default(),
-                    lfs: Some(GitLfs::Enabled),
+                    lfs: GitLfs::Enabled,
                 },
             })
         );
@@ -818,7 +820,7 @@ mod test {
                     git: Url::parse("https://test.url.git").unwrap(),
                     rev: Some(GitReference::Branch("main".to_string())),
                     subdirectory: Default::default(),
-                    lfs: Some(GitLfs::Disabled),
+                    lfs: GitLfs::Disabled,
                 },
             })
         );

--- a/crates/pixi_pypi_spec/src/toml.rs
+++ b/crates/pixi_pypi_spec/src/toml.rs
@@ -13,7 +13,7 @@ use url::Url;
 
 #[derive(Error, Debug)]
 pub enum SpecConversion {
-    #[error("`branch`, `rev`, and `tag` are only valid when `git` is specified")]
+    #[error("`branch`, `rev`, `tag`, and `lfs` are only valid when `git` is specified")]
     MissingGit,
     #[error("Only one of `branch` or `tag` or `rev` can be specified")]
     MultipleGitSpecifiers,
@@ -71,6 +71,7 @@ struct RawPyPiRequirement {
     pub branch: Option<String>,
     pub tag: Option<String>,
     pub rev: Option<String>,
+    pub lfs: Option<bool>,
 
     // Url only
     pub url: Option<Url>,
@@ -84,7 +85,11 @@ struct RawPyPiRequirement {
 
 impl RawPyPiRequirement {
     fn into_pypi_requirement(self) -> Result<PixiPypiSpec, SpecConversion> {
-        if self.git.is_none() && (self.branch.is_some() || self.rev.is_some() || self.tag.is_some())
+        if self.git.is_none()
+            && (self.branch.is_some()
+                || self.rev.is_some()
+                || self.tag.is_some()
+                || self.lfs.is_some())
         {
             return Err(SpecConversion::MissingGit);
         }
@@ -158,6 +163,7 @@ impl RawPyPiRequirement {
                                 .map(pixi_spec::Subdirectory::try_from)
                                 .transpose()?
                                 .unwrap_or_default(),
+                            lfs: self.lfs,
                         },
                     },
                     self.extras,
@@ -204,6 +210,7 @@ impl<'de> toml_span::Deserialize<'de> for RawPyPiRequirement {
         let rev = th
             .optional::<TomlFromStr<_>>("rev")
             .map(TomlFromStr::into_inner);
+        let lfs = th.optional("lfs");
 
         let url = th
             .optional::<TomlFromStr<_>>("url")
@@ -231,6 +238,7 @@ impl<'de> toml_span::Deserialize<'de> for RawPyPiRequirement {
             branch,
             tag,
             rev,
+            lfs,
             url,
             subdirectory,
             index,
@@ -336,6 +344,7 @@ impl From<PixiPypiSpec> for toml_edit::Value {
                         git,
                         rev,
                         subdirectory,
+                        lfs,
                     },
             } => {
                 let mut table = toml_edit::Table::new().into_inline_table();
@@ -374,6 +383,12 @@ impl From<PixiPypiSpec> for toml_edit::Value {
                         toml_edit::Value::String(toml_edit::Formatted::new(
                             subdirectory.to_string(),
                         )),
+                    );
+                }
+                if let Some(lfs) = lfs {
+                    table.insert(
+                        "lfs",
+                        toml_edit::Value::Boolean(toml_edit::Formatted::new(*lfs)),
                     );
                 }
                 insert_extras(&mut table, extras);
@@ -642,7 +657,7 @@ mod test {
     fn test_deserialize_fail_on_unknown() {
         let input = r#"foo = { borked = "bork"}"#;
         assert_snapshot!(format_parse_error(input, from_toml_str::<TomlIndexMap::<pep508_rs::PackageName, PixiPypiSpec>>(input).unwrap_err()), @r#"
-         × Unexpected keys, expected only 'version', 'extras', 'path', 'editable', 'git', 'branch', 'tag', 'rev', 'url', 'subdirectory', 'index', 'env-markers'
+         × Unexpected keys, expected only 'version', 'extras', 'path', 'editable', 'git', 'branch', 'tag', 'rev', 'lfs', 'url', 'subdirectory', 'index', 'env-markers'
           ╭─[pixi.toml:1:9]
         1 │ foo = { borked = "bork"}
           ·         ───┬──
@@ -682,6 +697,7 @@ mod test {
                     git: Url::parse("https://test.url.git").unwrap(),
                     rev: None,
                     subdirectory: Default::default(),
+                    lfs: None,
                 },
             })
         );
@@ -701,6 +717,7 @@ mod test {
                     git: Url::parse("https://test.url.git").unwrap(),
                     rev: Some(GitReference::Branch("main".to_string())),
                     subdirectory: Default::default(),
+                    lfs: None,
                 },
             })
         );
@@ -720,6 +737,7 @@ mod test {
                     git: Url::parse("https://test.url.git").unwrap(),
                     rev: Some(GitReference::Tag("v.1.2.3".to_string())),
                     subdirectory: Default::default(),
+                    lfs: None,
                 },
             })
         );
@@ -739,6 +757,7 @@ mod test {
                     git: Url::parse("https://github.com/pallets/flask.git").unwrap(),
                     rev: Some(GitReference::Tag("3.0.0".to_string())),
                     subdirectory: Default::default(),
+                    lfs: None,
                 },
             }),
         );
@@ -758,8 +777,62 @@ mod test {
                     git: Url::parse("https://test.url.git").unwrap(),
                     rev: Some(GitReference::Rev("123456".to_string())),
                     subdirectory: Default::default(),
+                    lfs: None,
                 },
             })
+        );
+    }
+
+    #[test]
+    fn test_deserialize_pypi_from_git_lfs() {
+        let requirement = from_toml_str::<TomlIndexMap<pep508_rs::PackageName, PixiPypiSpec>>(
+            r#"foo = { git = "https://test.url.git", lfs = true }"#,
+        )
+        .unwrap()
+        .into_inner();
+        assert_eq!(
+            requirement.first().unwrap().1,
+            &PixiPypiSpec::new(PixiPypiSource::Git {
+                git: GitSpec {
+                    git: Url::parse("https://test.url.git").unwrap(),
+                    rev: None,
+                    subdirectory: Default::default(),
+                    lfs: Some(true),
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn test_deserialize_pypi_from_git_lfs_false() {
+        let requirement = from_toml_str::<TomlIndexMap<pep508_rs::PackageName, PixiPypiSpec>>(
+            r#"foo = { git = "https://test.url.git", branch = "main", lfs = false }"#,
+        )
+        .unwrap()
+        .into_inner();
+        assert_eq!(
+            requirement.first().unwrap().1,
+            &PixiPypiSpec::new(PixiPypiSource::Git {
+                git: GitSpec {
+                    git: Url::parse("https://test.url.git").unwrap(),
+                    rev: Some(GitReference::Branch("main".to_string())),
+                    subdirectory: Default::default(),
+                    lfs: Some(false),
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn test_deserialize_pypi_lfs_without_git_fails() {
+        let result = from_toml_str::<TomlIndexMap<pep508_rs::PackageName, PixiPypiSpec>>(
+            r#"foo = { version = "*", lfs = true }"#,
+        );
+        let err = result.expect_err("lfs without git should fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("only valid when `git` is specified"),
+            "unexpected error: {msg}"
         );
     }
 }

--- a/crates/pixi_record/src/canonical_spec.rs
+++ b/crates/pixi_record/src/canonical_spec.rs
@@ -182,6 +182,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::Branch("main".to_string()),
+                lfs: None,
             },
         });
 
@@ -191,6 +192,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::Tag("v1.0.0".to_string()),
+                lfs: None,
             },
         });
 
@@ -208,6 +210,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         });
 
@@ -217,6 +220,7 @@ mod tests {
                 commit: GitSha::from_str("def456789012345678901234567890abcdabc123").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         });
 
@@ -235,6 +239,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         });
 
@@ -244,6 +249,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         });
 
@@ -261,6 +267,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Subdirectory::try_from("subdir1").unwrap(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         });
 
@@ -270,6 +277,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Subdirectory::try_from("subdir2").unwrap(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         });
 

--- a/crates/pixi_record/src/canonical_spec.rs
+++ b/crates/pixi_record/src/canonical_spec.rs
@@ -165,7 +165,7 @@ impl Display for CanonicalPath {
 mod tests {
     use std::str::FromStr;
 
-    use pixi_git::sha::GitSha;
+    use pixi_git::{GitLfs, sha::GitSha};
     use pixi_spec::{GitReference, Subdirectory};
     use url::Url;
 
@@ -182,7 +182,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::Branch("main".to_string()),
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         });
 
@@ -192,7 +192,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::Tag("v1.0.0".to_string()),
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         });
 
@@ -210,7 +210,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         });
 
@@ -220,7 +220,7 @@ mod tests {
                 commit: GitSha::from_str("def456789012345678901234567890abcdabc123").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         });
 
@@ -239,7 +239,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         });
 
@@ -249,7 +249,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         });
 
@@ -267,7 +267,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Subdirectory::try_from("subdir1").unwrap(),
                 reference: GitReference::DefaultBranch,
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         });
 
@@ -277,7 +277,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Subdirectory::try_from("subdir2").unwrap(),
                 reference: GitReference::DefaultBranch,
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         });
 

--- a/crates/pixi_record/src/pinned_source.rs
+++ b/crates/pixi_record/src/pinned_source.rs
@@ -149,7 +149,7 @@ impl PinnedSourceSpec {
     /// ```
     /// use pixi_record::{PinnedSourceSpec, PinnedGitSpec, PinnedGitCheckout};
     /// use pixi_spec::{SourceSpec, SourceLocationSpec, GitSpec, GitReference};
-    /// use pixi_git::sha::GitSha;
+    /// use pixi_git::{GitLfs, sha::GitSha};
     /// use url::Url;
     /// use std::str::FromStr;
     ///
@@ -161,7 +161,7 @@ impl PinnedSourceSpec {
     ///         commit: GitSha::from_str("abc123def456")?,
     ///         subdirectory: Default::default(),
     ///         reference: GitReference::DefaultBranch,
-    ///         lfs: None,
+    ///         lfs: GitLfs::Disabled,
     ///     },
     /// });
     ///
@@ -169,7 +169,7 @@ impl PinnedSourceSpec {
     ///     git: Url::parse("https://github.com/user/repo.git")?,
     ///     rev: None,
     ///     subdirectory: Default::default(),
-    ///     lfs: None,
+    ///     lfs: GitLfs::Disabled,
     /// });
     ///
     /// assert!(pinned_git.matches_source_spec(&source_spec));
@@ -313,11 +313,17 @@ pub struct PinnedGitCheckout {
     /// The reference of the git checkout.
     #[serde(default, skip_serializing_if = "GitReference::is_default")]
     pub reference: GitReference,
-    /// Whether git LFS was requested for this checkout. Recorded in the lock
-    /// file so reinstalls can re-validate LFS artifacts; `None` means LFS
-    /// was not requested.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub lfs: Option<GitLfs>,
+    /// Whether git LFS was requested for this checkout. Concrete (mirrors
+    /// uv): the manifest's tri-state was resolved at parse time, so what
+    /// gets pinned is exactly what was used. Locked URL only carries
+    /// `?lfs=true` when [`GitLfs::Enabled`]; absence parses back as
+    /// [`GitLfs::Disabled`].
+    #[serde(default, skip_serializing_if = "is_lfs_disabled")]
+    pub lfs: GitLfs,
+}
+
+fn is_lfs_disabled(lfs: &GitLfs) -> bool {
+    !lfs.is_enabled()
 }
 
 impl PinnedGitCheckout {
@@ -327,13 +333,13 @@ impl PinnedGitCheckout {
             commit,
             subdirectory,
             reference,
-            lfs: None,
+            lfs: GitLfs::Disabled,
         }
     }
 
     /// Sets the LFS flag.
     #[must_use]
-    pub fn with_lfs(mut self, lfs: Option<GitLfs>) -> Self {
+    pub fn with_lfs(mut self, lfs: GitLfs) -> Self {
         self.lfs = lfs;
         self
     }
@@ -410,7 +416,7 @@ impl PinnedGitCheckout {
                 .and_then(|s| Subdirectory::try_from(s).ok())
                 .unwrap_or_default(),
             reference: reference.expect("reference should be set"),
-            lfs,
+            lfs: lfs.unwrap_or(GitLfs::Disabled),
         })
     }
 }
@@ -474,11 +480,10 @@ impl PinnedGitSpec {
             GitReference::DefaultBranch => {}
         }
 
-        // Record an explicit lfs preference. `None` (unset) round-trips as
-        // an absent `?lfs=` query pair.
-        if let Some(lfs) = self.source.lfs {
-            url.query_pairs_mut()
-                .append_pair("lfs", if lfs.is_enabled() { "true" } else { "false" });
+        // Only write `?lfs=true` when enabled; absence parses back as
+        // Disabled (mirrors uv's lockfile pattern).
+        if self.source.lfs.is_enabled() {
+            url.query_pairs_mut().append_pair("lfs", "true");
         }
 
         // Put the precise commit in the fragment.
@@ -509,7 +514,7 @@ impl PinnedGitSpec {
                 commit: self.source.commit,
                 subdirectory: self.source.subdirectory.join(path.as_str()),
                 reference: self.source.reference.clone(),
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         }
     }
@@ -1013,7 +1018,7 @@ mod tests {
                 commit: GitSha::from_str("9de9e1b48cc421f05fc6aa6918cade3033a38c32").unwrap(),
                 subdirectory: Default::default(),
                 reference: pixi_spec::GitReference::Rev("9de9e1b".to_string()),
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         };
 
@@ -1021,7 +1026,7 @@ mod tests {
             git: Url::parse("https://github.com/example/repo.git").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
-            lfs: None,
+            lfs: GitLfs::Disabled,
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec);
@@ -1034,7 +1039,7 @@ mod tests {
                 commit: GitSha::from_str("9de9e1b48cc421f05fc6aa6918cade3033a38c32").unwrap(),
                 subdirectory: Default::default(),
                 reference: pixi_spec::GitReference::Rev("9de9e1b".to_string()),
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         };
 
@@ -1042,7 +1047,7 @@ mod tests {
             git: Url::parse("https://github.com/example/repo.git").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
-            lfs: None,
+            lfs: GitLfs::Disabled,
         };
 
         let result = locked_git_spec_without_git_suffix.satisfies(&requested_git_spec);
@@ -1055,7 +1060,7 @@ mod tests {
                 commit: GitSha::from_str("9de9e1b48cc421f05fc6aa6918cade3033a38c32").unwrap(),
                 subdirectory: Default::default(),
                 reference: pixi_spec::GitReference::Rev("9de9e1b".to_string()),
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         };
 
@@ -1063,7 +1068,7 @@ mod tests {
             git: Url::parse("https://github.com/example/repo").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
-            lfs: None,
+            lfs: GitLfs::Disabled,
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec_without_suffix);
@@ -1076,7 +1081,7 @@ mod tests {
                 commit: GitSha::from_str("9de9e1b48cc421f05fc6aa6918cade3033a38c32").unwrap(),
                 subdirectory: Default::default(),
                 reference: pixi_spec::GitReference::Rev("9de9e1b".to_string()),
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         };
 
@@ -1084,7 +1089,7 @@ mod tests {
             git: Url::parse("https://github.com/example/repo.git").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
-            lfs: None,
+            lfs: GitLfs::Disabled,
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec);
@@ -1097,7 +1102,7 @@ mod tests {
                 commit: GitSha::from_str("9de9e1b48cc421f05fc6aa6918cade3033a38c32").unwrap(),
                 subdirectory: Default::default(),
                 reference: pixi_spec::GitReference::Rev("9de9e1b".to_string()),
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         };
 
@@ -1105,7 +1110,7 @@ mod tests {
             git: Url::parse("git+https://github.com/example/repo.git").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
-            lfs: None,
+            lfs: GitLfs::Disabled,
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec_with_prefix);
@@ -1123,7 +1128,7 @@ mod tests {
                 commit: GitSha::from_str("9de9e1b48cc421f05fc6aa6918cade3033a38c32").unwrap(),
                 subdirectory: Default::default(),
                 reference: pixi_spec::GitReference::Rev("9de9e1b".to_string()),
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         };
 
@@ -1131,7 +1136,7 @@ mod tests {
             git: Url::parse("https://github.com/example/repo.git").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("d2e32".to_string())),
-            lfs: None,
+            lfs: GitLfs::Disabled,
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec).unwrap_err();
@@ -1146,7 +1151,7 @@ mod tests {
                 commit: GitSha::from_str("9de9e1b48cc421f05fc6aa6918cade3033a38c32").unwrap(),
                 subdirectory: Default::default(),
                 reference: pixi_spec::GitReference::Rev("9de9e1b".to_string()),
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         };
 
@@ -1154,7 +1159,7 @@ mod tests {
             git: Url::parse("https://github.com/example/repo.git").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
-            lfs: None,
+            lfs: GitLfs::Disabled,
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec).unwrap_err();
@@ -1169,7 +1174,7 @@ mod tests {
                 commit: GitSha::from_str("9de9e1b48cc421f05fc6aa6918cade3033a38c32").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         };
 
@@ -1179,7 +1184,7 @@ mod tests {
             // we are not specifying the rev
             // and request the default branch
             rev: None,
-            lfs: None,
+            lfs: GitLfs::Disabled,
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec);
@@ -1194,7 +1199,7 @@ mod tests {
                 commit: GitSha::from_str("9de9e1b48cc421f05fc6aa6918cade3033a38c32").unwrap(),
                 subdirectory: Subdirectory::try_from("some-subdir").unwrap(),
                 reference: GitReference::DefaultBranch,
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         };
 
@@ -1204,7 +1209,7 @@ mod tests {
             // we are not specifying the rev
             // and request the default branch
             rev: None,
-            lfs: None,
+            lfs: GitLfs::Disabled,
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec).unwrap_err();
@@ -1220,7 +1225,7 @@ mod tests {
                 commit: GitSha::from_str("9de9e1b48cc421f05fc6aa6918cade3033a38c32").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         };
 
@@ -1230,7 +1235,7 @@ mod tests {
             // we are not specifying the rev
             // and request the default branch
             rev: None,
-            lfs: None,
+            lfs: GitLfs::Disabled,
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec).unwrap_err();
@@ -1277,7 +1282,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         });
 
@@ -1285,7 +1290,7 @@ mod tests {
             git: Url::parse("https://github.com/user/repo.git").unwrap(),
             rev: None,
             subdirectory: Default::default(),
-            lfs: None,
+            lfs: GitLfs::Disabled,
         });
 
         // Should match despite .git suffix difference
@@ -1300,7 +1305,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         });
 
@@ -1308,7 +1313,7 @@ mod tests {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Default::default(),
-            lfs: None,
+            lfs: GitLfs::Disabled,
         });
 
         // Should match despite .git suffix difference
@@ -1323,7 +1328,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         });
 
@@ -1331,7 +1336,7 @@ mod tests {
             git: Url::parse("https://github.com/user/repo2").unwrap(),
             rev: None,
             subdirectory: Default::default(),
-            lfs: None,
+            lfs: GitLfs::Disabled,
         });
 
         assert!(!pinned.matches_source_spec(&spec));
@@ -1345,7 +1350,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Subdirectory::try_from("subdir").unwrap(),
                 reference: GitReference::DefaultBranch,
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         });
 
@@ -1353,7 +1358,7 @@ mod tests {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Default::default(),
-            lfs: None,
+            lfs: GitLfs::Disabled,
         });
 
         // Should match - spec doesn't care about subdirectory
@@ -1368,7 +1373,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Subdirectory::try_from("subdir").unwrap(),
                 reference: GitReference::DefaultBranch,
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         });
 
@@ -1376,7 +1381,7 @@ mod tests {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Subdirectory::try_from("subdir").unwrap(),
-            lfs: None,
+            lfs: GitLfs::Disabled,
         });
 
         assert!(pinned.matches_source_spec(&spec));
@@ -1390,7 +1395,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Subdirectory::try_from("subdir1").unwrap(),
                 reference: GitReference::DefaultBranch,
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         });
 
@@ -1398,7 +1403,7 @@ mod tests {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Subdirectory::try_from("subdir2").unwrap(),
-            lfs: None,
+            lfs: GitLfs::Disabled,
         });
 
         assert!(!pinned.matches_source_spec(&spec));
@@ -1412,7 +1417,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         });
 
@@ -1420,7 +1425,7 @@ mod tests {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Subdirectory::try_from("subdir").unwrap(),
-            lfs: None,
+            lfs: GitLfs::Disabled,
         });
 
         // Should not match - spec requires a subdirectory that pinned doesn't have
@@ -1481,7 +1486,7 @@ mod tests {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Default::default(),
-            lfs: None,
+            lfs: GitLfs::Disabled,
         });
 
         assert!(!pinned.matches_source_spec(&spec));
@@ -1495,7 +1500,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         });
 
@@ -1540,7 +1545,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::Rev("v1.0.0".to_string()),
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         });
 
@@ -1548,7 +1553,7 @@ mod tests {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: Some(GitReference::Rev("v2.0.0".to_string())),
             subdirectory: Default::default(),
-            lfs: None,
+            lfs: GitLfs::Disabled,
         });
 
         assert!(!pinned.matches_source_spec(&spec));
@@ -1564,7 +1569,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::Branch("main".to_string()),
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         });
 
@@ -1572,7 +1577,7 @@ mod tests {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: Some(GitReference::Branch("main".to_string())),
             subdirectory: Default::default(),
-            lfs: None,
+            lfs: GitLfs::Disabled,
         });
 
         assert!(pinned.matches_source_spec(&spec));
@@ -1586,7 +1591,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         });
 
@@ -1594,7 +1599,7 @@ mod tests {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Default::default(),
-            lfs: None,
+            lfs: GitLfs::Disabled,
         });
 
         // Should match - GitHub URLs are case-insensitive
@@ -1623,7 +1628,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456abc123def456abc123def456abc1").unwrap(),
                 subdirectory: Subdirectory::new("recipes").unwrap(),
                 reference: GitReference::DefaultBranch,
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         };
 
@@ -1644,7 +1649,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456abc123def456abc123def456abc1").unwrap(),
                 subdirectory: Subdirectory::default(),
                 reference: GitReference::DefaultBranch,
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         };
 
@@ -1667,7 +1672,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456abc123def456abc123def456abc1").unwrap(),
                 subdirectory: Subdirectory::default(),
                 reference: GitReference::Branch("main".to_string()),
-                lfs: Some(GitLfs::Enabled),
+                lfs: GitLfs::Enabled,
             },
         };
 
@@ -1679,7 +1684,7 @@ mod tests {
         );
 
         let parsed = PinnedGitCheckout::from_locked_url(&url).unwrap();
-        assert_eq!(parsed.lfs, Some(GitLfs::Enabled));
+        assert_eq!(parsed.lfs, GitLfs::Enabled);
         assert_eq!(parsed.reference, GitReference::Branch("main".to_string()));
     }
 
@@ -1694,7 +1699,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456abc123def456abc123def456abc1").unwrap(),
                 subdirectory: Subdirectory::default(),
                 reference: GitReference::DefaultBranch,
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         };
 

--- a/crates/pixi_record/src/pinned_source.rs
+++ b/crates/pixi_record/src/pinned_source.rs
@@ -1,7 +1,7 @@
 #![deny(missing_docs)]
 use miette::IntoDiagnostic;
 use pixi_git::{
-    GitUrl,
+    GitLfs, GitUrl,
     sha::GitSha,
     url::{RepositoryUrl, redact_credentials},
 };
@@ -317,7 +317,7 @@ pub struct PinnedGitCheckout {
     /// file so reinstalls can re-validate LFS artifacts; `None` means LFS
     /// was not requested.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub lfs: Option<bool>,
+    pub lfs: Option<GitLfs>,
 }
 
 impl PinnedGitCheckout {
@@ -333,7 +333,7 @@ impl PinnedGitCheckout {
 
     /// Sets the LFS flag.
     #[must_use]
-    pub fn with_lfs(mut self, lfs: Option<bool>) -> Self {
+    pub fn with_lfs(mut self, lfs: Option<GitLfs>) -> Self {
         self.lfs = lfs;
         self
     }
@@ -382,8 +382,8 @@ impl PinnedGitCheckout {
                 }
                 "lfs" => {
                     let parsed = match val.as_ref() {
-                        "true" | "1" => true,
-                        "false" | "0" => false,
+                        "true" | "1" => GitLfs::Enabled,
+                        "false" | "0" => GitLfs::Disabled,
                         other => {
                             return Err(miette::miette!("invalid lfs value in URL: {other}"));
                         }
@@ -478,7 +478,7 @@ impl PinnedGitSpec {
         // an absent `?lfs=` query pair.
         if let Some(lfs) = self.source.lfs {
             url.query_pairs_mut()
-                .append_pair("lfs", if lfs { "true" } else { "false" });
+                .append_pair("lfs", if lfs.is_enabled() { "true" } else { "false" });
         }
 
         // Put the precise commit in the fragment.
@@ -997,7 +997,7 @@ impl From<PinnedGitSpec> for GitSpec {
 mod tests {
     use std::str::FromStr;
 
-    use pixi_git::sha::GitSha;
+    use pixi_git::{GitLfs, sha::GitSha};
     use pixi_spec::{GitReference, GitSpec, Subdirectory};
     use url::Url;
 
@@ -1667,7 +1667,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456abc123def456abc123def456abc1").unwrap(),
                 subdirectory: Subdirectory::default(),
                 reference: GitReference::Branch("main".to_string()),
-                lfs: Some(true),
+                lfs: Some(GitLfs::Enabled),
             },
         };
 
@@ -1679,7 +1679,7 @@ mod tests {
         );
 
         let parsed = PinnedGitCheckout::from_locked_url(&url).unwrap();
-        assert_eq!(parsed.lfs, Some(true));
+        assert_eq!(parsed.lfs, Some(GitLfs::Enabled));
         assert_eq!(parsed.reference, GitReference::Branch("main".to_string()));
     }
 

--- a/crates/pixi_record/src/pinned_source.rs
+++ b/crates/pixi_record/src/pinned_source.rs
@@ -161,6 +161,7 @@ impl PinnedSourceSpec {
     ///         commit: GitSha::from_str("abc123def456")?,
     ///         subdirectory: Default::default(),
     ///         reference: GitReference::DefaultBranch,
+    ///         lfs: None,
     ///     },
     /// });
     ///
@@ -168,6 +169,7 @@ impl PinnedSourceSpec {
     ///     git: Url::parse("https://github.com/user/repo.git")?,
     ///     rev: None,
     ///     subdirectory: Default::default(),
+    ///     lfs: None,
     /// });
     ///
     /// assert!(pinned_git.matches_source_spec(&source_spec));
@@ -311,6 +313,11 @@ pub struct PinnedGitCheckout {
     /// The reference of the git checkout.
     #[serde(default, skip_serializing_if = "GitReference::is_default")]
     pub reference: GitReference,
+    /// Whether git LFS was requested for this checkout. Recorded in the lock
+    /// file so reinstalls can re-validate LFS artifacts; `None` means LFS
+    /// was not requested.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lfs: Option<bool>,
 }
 
 impl PinnedGitCheckout {
@@ -320,7 +327,15 @@ impl PinnedGitCheckout {
             commit,
             subdirectory,
             reference,
+            lfs: None,
         }
+    }
+
+    /// Sets the LFS flag.
+    #[must_use]
+    pub fn with_lfs(mut self, lfs: Option<bool>) -> Self {
+        self.lfs = lfs;
+        self
     }
 
     /// Extracts a pinned git checkout from the query pairs and the hash
@@ -329,6 +344,7 @@ impl PinnedGitCheckout {
         let url = &locked_url.0;
         let mut reference = None;
         let mut subdirectory = None;
+        let mut lfs = None;
 
         for (key, val) in url.query_pairs() {
             match &*key {
@@ -364,6 +380,18 @@ impl PinnedGitCheckout {
                         return Err(miette::miette!("multiple subdirectories in URL"));
                     }
                 }
+                "lfs" => {
+                    let parsed = match val.as_ref() {
+                        "true" | "1" => true,
+                        "false" | "0" => false,
+                        other => {
+                            return Err(miette::miette!("invalid lfs value in URL: {other}"));
+                        }
+                    };
+                    if lfs.replace(parsed).is_some() {
+                        return Err(miette::miette!("multiple lfs flags in URL"));
+                    }
+                }
                 _ => continue,
             };
         }
@@ -382,6 +410,7 @@ impl PinnedGitCheckout {
                 .and_then(|s| Subdirectory::try_from(s).ok())
                 .unwrap_or_default(),
             reference: reference.expect("reference should be set"),
+            lfs,
         })
     }
 }
@@ -445,6 +474,13 @@ impl PinnedGitSpec {
             GitReference::DefaultBranch => {}
         }
 
+        // Record an explicit lfs preference. `None` (unset) round-trips as
+        // an absent `?lfs=` query pair.
+        if let Some(lfs) = self.source.lfs {
+            url.query_pairs_mut()
+                .append_pair("lfs", if lfs { "true" } else { "false" });
+        }
+
         // Put the precise commit in the fragment.
         url.set_fragment(self.source.commit.to_string().as_str().into());
 
@@ -473,6 +509,7 @@ impl PinnedGitSpec {
                 commit: self.source.commit,
                 subdirectory: self.source.subdirectory.join(path.as_str()),
                 reference: self.source.reference.clone(),
+                lfs: None,
             },
         }
     }
@@ -951,6 +988,7 @@ impl From<PinnedGitSpec> for GitSpec {
             git: value.git,
             subdirectory: value.source.subdirectory,
             rev: Some(value.source.reference),
+            lfs: value.source.lfs,
         }
     }
 }
@@ -975,6 +1013,7 @@ mod tests {
                 commit: GitSha::from_str("9de9e1b48cc421f05fc6aa6918cade3033a38c32").unwrap(),
                 subdirectory: Default::default(),
                 reference: pixi_spec::GitReference::Rev("9de9e1b".to_string()),
+                lfs: None,
             },
         };
 
@@ -982,6 +1021,7 @@ mod tests {
             git: Url::parse("https://github.com/example/repo.git").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
+            lfs: None,
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec);
@@ -994,6 +1034,7 @@ mod tests {
                 commit: GitSha::from_str("9de9e1b48cc421f05fc6aa6918cade3033a38c32").unwrap(),
                 subdirectory: Default::default(),
                 reference: pixi_spec::GitReference::Rev("9de9e1b".to_string()),
+                lfs: None,
             },
         };
 
@@ -1001,6 +1042,7 @@ mod tests {
             git: Url::parse("https://github.com/example/repo.git").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
+            lfs: None,
         };
 
         let result = locked_git_spec_without_git_suffix.satisfies(&requested_git_spec);
@@ -1013,6 +1055,7 @@ mod tests {
                 commit: GitSha::from_str("9de9e1b48cc421f05fc6aa6918cade3033a38c32").unwrap(),
                 subdirectory: Default::default(),
                 reference: pixi_spec::GitReference::Rev("9de9e1b".to_string()),
+                lfs: None,
             },
         };
 
@@ -1020,6 +1063,7 @@ mod tests {
             git: Url::parse("https://github.com/example/repo").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
+            lfs: None,
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec_without_suffix);
@@ -1032,6 +1076,7 @@ mod tests {
                 commit: GitSha::from_str("9de9e1b48cc421f05fc6aa6918cade3033a38c32").unwrap(),
                 subdirectory: Default::default(),
                 reference: pixi_spec::GitReference::Rev("9de9e1b".to_string()),
+                lfs: None,
             },
         };
 
@@ -1039,6 +1084,7 @@ mod tests {
             git: Url::parse("https://github.com/example/repo.git").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
+            lfs: None,
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec);
@@ -1051,6 +1097,7 @@ mod tests {
                 commit: GitSha::from_str("9de9e1b48cc421f05fc6aa6918cade3033a38c32").unwrap(),
                 subdirectory: Default::default(),
                 reference: pixi_spec::GitReference::Rev("9de9e1b".to_string()),
+                lfs: None,
             },
         };
 
@@ -1058,6 +1105,7 @@ mod tests {
             git: Url::parse("git+https://github.com/example/repo.git").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
+            lfs: None,
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec_with_prefix);
@@ -1075,6 +1123,7 @@ mod tests {
                 commit: GitSha::from_str("9de9e1b48cc421f05fc6aa6918cade3033a38c32").unwrap(),
                 subdirectory: Default::default(),
                 reference: pixi_spec::GitReference::Rev("9de9e1b".to_string()),
+                lfs: None,
             },
         };
 
@@ -1082,6 +1131,7 @@ mod tests {
             git: Url::parse("https://github.com/example/repo.git").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("d2e32".to_string())),
+            lfs: None,
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec).unwrap_err();
@@ -1096,6 +1146,7 @@ mod tests {
                 commit: GitSha::from_str("9de9e1b48cc421f05fc6aa6918cade3033a38c32").unwrap(),
                 subdirectory: Default::default(),
                 reference: pixi_spec::GitReference::Rev("9de9e1b".to_string()),
+                lfs: None,
             },
         };
 
@@ -1103,6 +1154,7 @@ mod tests {
             git: Url::parse("https://github.com/example/repo.git").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
+            lfs: None,
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec).unwrap_err();
@@ -1117,6 +1169,7 @@ mod tests {
                 commit: GitSha::from_str("9de9e1b48cc421f05fc6aa6918cade3033a38c32").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         };
 
@@ -1126,6 +1179,7 @@ mod tests {
             // we are not specifying the rev
             // and request the default branch
             rev: None,
+            lfs: None,
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec);
@@ -1140,6 +1194,7 @@ mod tests {
                 commit: GitSha::from_str("9de9e1b48cc421f05fc6aa6918cade3033a38c32").unwrap(),
                 subdirectory: Subdirectory::try_from("some-subdir").unwrap(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         };
 
@@ -1149,6 +1204,7 @@ mod tests {
             // we are not specifying the rev
             // and request the default branch
             rev: None,
+            lfs: None,
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec).unwrap_err();
@@ -1164,6 +1220,7 @@ mod tests {
                 commit: GitSha::from_str("9de9e1b48cc421f05fc6aa6918cade3033a38c32").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         };
 
@@ -1173,6 +1230,7 @@ mod tests {
             // we are not specifying the rev
             // and request the default branch
             rev: None,
+            lfs: None,
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec).unwrap_err();
@@ -1219,6 +1277,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         });
 
@@ -1226,6 +1285,7 @@ mod tests {
             git: Url::parse("https://github.com/user/repo.git").unwrap(),
             rev: None,
             subdirectory: Default::default(),
+            lfs: None,
         });
 
         // Should match despite .git suffix difference
@@ -1240,6 +1300,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         });
 
@@ -1247,6 +1308,7 @@ mod tests {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Default::default(),
+            lfs: None,
         });
 
         // Should match despite .git suffix difference
@@ -1261,6 +1323,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         });
 
@@ -1268,6 +1331,7 @@ mod tests {
             git: Url::parse("https://github.com/user/repo2").unwrap(),
             rev: None,
             subdirectory: Default::default(),
+            lfs: None,
         });
 
         assert!(!pinned.matches_source_spec(&spec));
@@ -1281,6 +1345,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Subdirectory::try_from("subdir").unwrap(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         });
 
@@ -1288,6 +1353,7 @@ mod tests {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Default::default(),
+            lfs: None,
         });
 
         // Should match - spec doesn't care about subdirectory
@@ -1302,6 +1368,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Subdirectory::try_from("subdir").unwrap(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         });
 
@@ -1309,6 +1376,7 @@ mod tests {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Subdirectory::try_from("subdir").unwrap(),
+            lfs: None,
         });
 
         assert!(pinned.matches_source_spec(&spec));
@@ -1322,6 +1390,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Subdirectory::try_from("subdir1").unwrap(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         });
 
@@ -1329,6 +1398,7 @@ mod tests {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Subdirectory::try_from("subdir2").unwrap(),
+            lfs: None,
         });
 
         assert!(!pinned.matches_source_spec(&spec));
@@ -1342,6 +1412,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         });
 
@@ -1349,6 +1420,7 @@ mod tests {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Subdirectory::try_from("subdir").unwrap(),
+            lfs: None,
         });
 
         // Should not match - spec requires a subdirectory that pinned doesn't have
@@ -1409,6 +1481,7 @@ mod tests {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Default::default(),
+            lfs: None,
         });
 
         assert!(!pinned.matches_source_spec(&spec));
@@ -1422,6 +1495,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         });
 
@@ -1466,6 +1540,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::Rev("v1.0.0".to_string()),
+                lfs: None,
             },
         });
 
@@ -1473,6 +1548,7 @@ mod tests {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: Some(GitReference::Rev("v2.0.0".to_string())),
             subdirectory: Default::default(),
+            lfs: None,
         });
 
         assert!(!pinned.matches_source_spec(&spec));
@@ -1488,6 +1564,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::Branch("main".to_string()),
+                lfs: None,
             },
         });
 
@@ -1495,6 +1572,7 @@ mod tests {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: Some(GitReference::Branch("main".to_string())),
             subdirectory: Default::default(),
+            lfs: None,
         });
 
         assert!(pinned.matches_source_spec(&spec));
@@ -1508,6 +1586,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         });
 
@@ -1515,6 +1594,7 @@ mod tests {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Default::default(),
+            lfs: None,
         });
 
         // Should match - GitHub URLs are case-insensitive
@@ -1543,6 +1623,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456abc123def456abc123def456abc1").unwrap(),
                 subdirectory: Subdirectory::new("recipes").unwrap(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         };
 
@@ -1563,6 +1644,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456abc123def456abc123def456abc1").unwrap(),
                 subdirectory: Subdirectory::default(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         };
 
@@ -1570,6 +1652,57 @@ mod tests {
         assert_eq!(
             joined.source.subdirectory.to_option_string(),
             Some("src/lib".to_string())
+        );
+    }
+
+    /// `lfs=true` round-trips through the locked URL: it appears as a
+    /// `?lfs=true` query pair and reads back into `PinnedGitCheckout.lfs`.
+    /// Without this, the lock file would silently drop the LFS preference
+    /// and reinstalls would fail to fetch LFS artifacts.
+    #[test]
+    fn test_pinned_git_lfs_roundtrip() {
+        let spec = PinnedGitSpec {
+            git: Url::parse("https://github.com/example/lfs-repo.git").unwrap(),
+            source: PinnedGitCheckout {
+                commit: GitSha::from_str("abc123def456abc123def456abc123def456abc1").unwrap(),
+                subdirectory: Subdirectory::default(),
+                reference: GitReference::Branch("main".to_string()),
+                lfs: Some(true),
+            },
+        };
+
+        let url = spec.into_locked_git_url();
+        let url_str = url.to_url().to_string();
+        assert!(
+            url_str.contains("lfs=true"),
+            "expected lfs=true in {url_str}"
+        );
+
+        let parsed = PinnedGitCheckout::from_locked_url(&url).unwrap();
+        assert_eq!(parsed.lfs, Some(true));
+        assert_eq!(parsed.reference, GitReference::Branch("main".to_string()));
+    }
+
+    /// `lfs = None` (the default) must NOT show up in the locked URL —
+    /// emitting `?lfs=` for every git dep would churn lock files for
+    /// projects that don't use LFS at all.
+    #[test]
+    fn test_pinned_git_no_lfs_does_not_serialize() {
+        let spec = PinnedGitSpec {
+            git: Url::parse("https://github.com/example/repo.git").unwrap(),
+            source: PinnedGitCheckout {
+                commit: GitSha::from_str("abc123def456abc123def456abc123def456abc1").unwrap(),
+                subdirectory: Subdirectory::default(),
+                reference: GitReference::DefaultBranch,
+                lfs: None,
+            },
+        };
+
+        let url = spec.into_locked_git_url();
+        assert!(
+            !url.to_url().to_string().contains("lfs"),
+            "URL unexpectedly contains 'lfs': {}",
+            url.to_url()
         );
     }
 }

--- a/crates/pixi_record/src/source_record.rs
+++ b/crates/pixi_record/src/source_record.rs
@@ -710,6 +710,7 @@ fn package_build_source_to_build_source(
                             .and_then(|s| pixi_spec::Subdirectory::try_from(s.to_string()).ok())
                             .unwrap_or_default(),
                         reference,
+                        lfs: None,
                     },
                 }),
             )))
@@ -1164,6 +1165,7 @@ mod tests {
                     .unwrap(),
                 subdirectory: Default::default(),
                 reference: pixi_spec::GitReference::DefaultBranch,
+                lfs: None,
             },
         })
     }

--- a/crates/pixi_record/src/source_record.rs
+++ b/crates/pixi_record/src/source_record.rs
@@ -27,7 +27,7 @@
 //! Use [`SourceRecord::map_data`] and [`SourceRecord::try_map_data`] for clean
 //! state transitions without field-by-field reconstruction.
 
-use pixi_git::sha::GitSha;
+use pixi_git::{GitLfs, sha::GitSha};
 use pixi_spec::{GitReference, SourceLocationSpec};
 use rattler_conda_types::{
     Flag, MatchSpec, Matches, NamelessMatchSpec, PackageName, PackageRecord, PackageUrl,
@@ -710,7 +710,7 @@ fn package_build_source_to_build_source(
                             .and_then(|s| pixi_spec::Subdirectory::try_from(s.to_string()).ok())
                             .unwrap_or_default(),
                         reference,
-                        lfs: None,
+                        lfs: GitLfs::Disabled,
                     },
                 }),
             )))
@@ -1165,7 +1165,7 @@ mod tests {
                     .unwrap(),
                 subdirectory: Default::default(),
                 reference: pixi_spec::GitReference::DefaultBranch,
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         })
     }

--- a/crates/pixi_spec/src/git.rs
+++ b/crates/pixi_spec/src/git.rs
@@ -22,9 +22,8 @@ pub struct GitSpec {
     #[serde(skip_serializing_if = "Subdirectory::is_empty", default)]
     pub subdirectory: Subdirectory,
 
-    /// Whether to fetch git LFS objects for this checkout. Concrete by the
-    /// time we hit this struct: the manifest's `lfs = true/false` (or its
-    /// absence + `PIXI_GIT_LFS`) was already resolved via
+    /// Whether to fetch git LFS objects for this checkout. The manifest's
+    /// `lfs = true/false` (absence → `Disabled`) was resolved via
     /// [`GitLfs::from`]`(Option<bool>)`. Serialised as a plain bool, and
     /// skipped when [`GitLfs::Disabled`] so existing manifests don't churn.
     #[serde(default, skip_serializing_if = "is_lfs_disabled")]

--- a/crates/pixi_spec/src/git.rs
+++ b/crates/pixi_spec/src/git.rs
@@ -22,11 +22,17 @@ pub struct GitSpec {
     #[serde(skip_serializing_if = "Subdirectory::is_empty", default)]
     pub subdirectory: Subdirectory,
 
-    /// Whether to fetch git LFS objects for this checkout. `None` defers to
-    /// [`GitLfs::from_env`]; `Some(_)` is an explicit override. Serialised
-    /// as a plain bool to match `lfs = true/false` in TOML.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub lfs: Option<GitLfs>,
+    /// Whether to fetch git LFS objects for this checkout. Concrete by the
+    /// time we hit this struct: the manifest's `lfs = true/false` (or its
+    /// absence + `PIXI_GIT_LFS`) was already resolved via
+    /// [`GitLfs::from`]`(Option<bool>)`. Serialised as a plain bool, and
+    /// skipped when [`GitLfs::Disabled`] so existing manifests don't churn.
+    #[serde(default, skip_serializing_if = "is_lfs_disabled")]
+    pub lfs: GitLfs,
+}
+
+fn is_lfs_disabled(lfs: &GitLfs) -> bool {
+    !lfs.is_enabled()
 }
 
 impl Display for GitSpec {
@@ -38,7 +44,7 @@ impl Display for GitSpec {
         if !self.subdirectory.is_empty() {
             write!(f, " in {}", self.subdirectory)?;
         }
-        if self.lfs == Some(GitLfs::Enabled) {
+        if self.lfs.is_enabled() {
             write!(f, " (lfs)")?;
         }
         Ok(())

--- a/crates/pixi_spec/src/git.rs
+++ b/crates/pixi_spec/src/git.rs
@@ -21,6 +21,12 @@ pub struct GitSpec {
     /// The git subdirectory of the package
     #[serde(skip_serializing_if = "Subdirectory::is_empty", default)]
     pub subdirectory: Subdirectory,
+
+    /// Whether to fetch git LFS objects for this checkout. `None` defers to
+    /// the `PIXI_GIT_LFS` env var; `Some(true)` / `Some(false)` is an
+    /// explicit override.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lfs: Option<bool>,
 }
 
 impl Display for GitSpec {
@@ -31,6 +37,9 @@ impl Display for GitSpec {
         }
         if !self.subdirectory.is_empty() {
             write!(f, " in {}", self.subdirectory)?;
+        }
+        if self.lfs == Some(true) {
+            write!(f, " (lfs)")?;
         }
         Ok(())
     }

--- a/crates/pixi_spec/src/git.rs
+++ b/crates/pixi_spec/src/git.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use pixi_git::git;
+use pixi_git::{GitLfs, git};
 use serde::{Serialize, Serializer};
 use thiserror::Error;
 use url::Url;
@@ -23,10 +23,10 @@ pub struct GitSpec {
     pub subdirectory: Subdirectory,
 
     /// Whether to fetch git LFS objects for this checkout. `None` defers to
-    /// the `PIXI_GIT_LFS` env var; `Some(true)` / `Some(false)` is an
-    /// explicit override.
+    /// [`GitLfs::from_env`]; `Some(_)` is an explicit override. Serialised
+    /// as a plain bool to match `lfs = true/false` in TOML.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub lfs: Option<bool>,
+    pub lfs: Option<GitLfs>,
 }
 
 impl Display for GitSpec {
@@ -38,7 +38,7 @@ impl Display for GitSpec {
         if !self.subdirectory.is_empty() {
             write!(f, " in {}", self.subdirectory)?;
         }
-        if self.lfs == Some(true) {
+        if self.lfs == Some(GitLfs::Enabled) {
             write!(f, " (lfs)")?;
         }
         Ok(())

--- a/crates/pixi_spec/src/lib.rs
+++ b/crates/pixi_spec/src/lib.rs
@@ -19,6 +19,7 @@ mod subdirectory;
 mod toml;
 mod url;
 
+use pixi_git::GitLfs;
 use std::{fmt::Display, path::PathBuf, str::FromStr};
 
 pub use detailed::DetailedSpec;
@@ -794,7 +795,7 @@ impl From<rattler_lock::source::GitSourceLocation> for GitSpec {
                 .subdirectory
                 .and_then(|s| Subdirectory::try_from(s).ok())
                 .unwrap_or_default(),
-            lfs: None,
+            lfs: GitLfs::Disabled,
         }
     }
 }

--- a/crates/pixi_spec/src/lib.rs
+++ b/crates/pixi_spec/src/lib.rs
@@ -794,6 +794,7 @@ impl From<rattler_lock::source::GitSourceLocation> for GitSpec {
                 .subdirectory
                 .and_then(|s| Subdirectory::try_from(s).ok())
                 .unwrap_or_default(),
+            lfs: None,
         }
     }
 }

--- a/crates/pixi_spec/src/source_anchor.rs
+++ b/crates/pixi_spec/src/source_anchor.rs
@@ -82,6 +82,7 @@ impl SourceAnchor {
                 git,
                 rev,
                 subdirectory,
+                lfs,
             }) => {
                 let base_subdir = subdirectory.as_path().to_string_lossy();
                 let relative_subdir = normalize::normalize_typed(
@@ -100,6 +101,7 @@ impl SourceAnchor {
                     git: git.clone(),
                     rev: rev.clone(),
                     subdirectory,
+                    lfs: *lfs,
                 })
             }
         }

--- a/crates/pixi_spec/src/toml.rs
+++ b/crates/pixi_spec/src/toml.rs
@@ -649,7 +649,7 @@ impl TomlSpec {
                         git,
                         rev,
                         subdirectory,
-                        lfs: loc.lfs,
+                        lfs: loc.lfs.map(pixi_git::GitLfs::from),
                     })
                 }
                 (None, None, None) => {
@@ -1168,7 +1168,7 @@ impl TomlLocationSpec {
                     git,
                     rev,
                     subdirectory,
-                    lfs: self.lfs,
+                    lfs: self.lfs.map(pixi_git::GitLfs::from),
                 })
             }
             (_, _, _) => return Err(SourceLocationSpecError::MultipleIdentifiers),
@@ -1671,7 +1671,7 @@ mod test {
         }))
         .expect("parse should succeed");
         let git = spec.as_git().expect("expected a git spec");
-        assert_eq!(git.lfs, Some(true));
+        assert_eq!(git.lfs, Some(pixi_git::GitLfs::Enabled));
     }
 
     /// `lfs` without `git` is rejected the same way `branch` / `rev` / `tag`

--- a/crates/pixi_spec/src/toml.rs
+++ b/crates/pixi_spec/src/toml.rs
@@ -270,6 +270,9 @@ pub struct TomlLocationSpec {
     /// The git subdirectory of the package
     pub subdirectory: Option<String>,
 
+    /// Whether to fetch git LFS objects when checking out this source.
+    pub lfs: Option<bool>,
+
     /// The md5 hash of the package
     #[serde_as(as = "Option<rattler_digest::serde::SerializableHash::<rattler_digest::Md5>>")]
     pub md5: Option<Md5Hash>,
@@ -339,7 +342,7 @@ fn version_spec_error<T: Into<String>>(input: T) -> Option<impl Display> {
 
 #[derive(Error, Debug)]
 pub enum SpecError {
-    #[error("`branch`, `rev`, and `tag` are only valid when `git` is specified")]
+    #[error("`branch`, `rev`, `tag`, and `lfs` are only valid when `git` is specified")]
     NotAGitSpec,
 
     #[error("only one of `branch`, `rev`, or `tag` can be specified")]
@@ -398,7 +401,7 @@ impl SpecError {
 
 #[derive(Error, Debug)]
 pub enum SourceLocationSpecError {
-    #[error("`branch`, `rev`, and `tag` are only valid when `git` is specified")]
+    #[error("`branch`, `rev`, `tag`, and `lfs` are only valid when `git` is specified")]
     NotAGitSpec,
 
     #[error("only one of `branch`, `rev`, or `tag` can be specified")]
@@ -466,6 +469,7 @@ impl TomlSpec {
                 rev: m.rev.or(b.rev),
                 tag: m.tag.or(b.tag),
                 subdirectory: m.subdirectory.or(b.subdirectory),
+                lfs: m.lfs.or(b.lfs),
                 md5: m.md5.or(b.md5),
                 sha256: m.sha256.or(b.sha256),
             }),
@@ -537,7 +541,11 @@ impl TomlSpec {
 
     fn validate_field_combinations(&self) -> Result<(), SpecError> {
         let (is_git, is_path, is_url) = if let Some(loc) = &self.location {
-            if loc.git.is_none() && (loc.branch.is_some() || loc.rev.is_some() || loc.tag.is_some())
+            if loc.git.is_none()
+                && (loc.branch.is_some()
+                    || loc.rev.is_some()
+                    || loc.tag.is_some()
+                    || loc.lfs.is_some())
             {
                 return Err(SpecError::NotAGitSpec);
             }
@@ -641,6 +649,7 @@ impl TomlSpec {
                         git,
                         rev,
                         subdirectory,
+                        lfs: loc.lfs,
                     })
                 }
                 (None, None, None) => {
@@ -1085,7 +1094,10 @@ impl TomlLocationSpec {
     fn validate_field_combinations(&self) -> Result<(), SourceLocationSpecError> {
         let (is_git, is_path, is_url) = {
             if self.git.is_none()
-                && (self.branch.is_some() || self.rev.is_some() || self.tag.is_some())
+                && (self.branch.is_some()
+                    || self.rev.is_some()
+                    || self.tag.is_some()
+                    || self.lfs.is_some())
             {
                 return Err(SourceLocationSpecError::NotAGitSpec);
             }
@@ -1156,6 +1168,7 @@ impl TomlLocationSpec {
                     git,
                     rev,
                     subdirectory,
+                    lfs: self.lfs,
                 })
             }
             (_, _, _) => return Err(SourceLocationSpecError::MultipleIdentifiers),
@@ -1221,6 +1234,7 @@ impl<'de> toml_span::Deserialize<'de> for TomlSpec {
         let rev = th.optional("rev");
         let tag = th.optional("tag");
         let subdirectory = th.optional("subdirectory");
+        let lfs = th.optional("lfs");
         let build = th
             .optional::<TomlFromStr<_>>("build")
             .map(TomlFromStr::into_inner);
@@ -1257,6 +1271,7 @@ impl<'de> toml_span::Deserialize<'de> for TomlSpec {
                 rev,
                 tag,
                 subdirectory,
+                lfs,
                 md5,
                 sha256,
             }),
@@ -1387,6 +1402,7 @@ impl<'de> toml_span::Deserialize<'de> for TomlLocationSpec {
         let rev = th.optional("rev");
         let tag = th.optional("tag");
         let subdirectory = th.optional("subdirectory");
+        let lfs = th.optional("lfs");
         let md5 = th
             .optional::<TomlDigest<rattler_digest::Md5>>("md5")
             .map(TomlDigest::into_inner);
@@ -1404,6 +1420,7 @@ impl<'de> toml_span::Deserialize<'de> for TomlLocationSpec {
             rev,
             tag,
             subdirectory,
+            lfs,
             md5,
             sha256,
         })
@@ -1642,6 +1659,35 @@ mod test {
         }
 
         insta::assert_yaml_snapshot!(snapshot);
+    }
+
+    /// `lfs = true` on a conda git spec parses into `GitSpec.lfs == Some(true)`
+    /// so the downstream resolver can request LFS artifacts.
+    #[test]
+    fn test_conda_git_lfs_parses() {
+        let spec: PixiSpec = serde_json::from_value(json!({
+            "git": "https://github.com/example/repo",
+            "lfs": true,
+        }))
+        .expect("parse should succeed");
+        let git = spec.as_git().expect("expected a git spec");
+        assert_eq!(git.lfs, Some(true));
+    }
+
+    /// `lfs` without `git` is rejected the same way `branch` / `rev` / `tag`
+    /// are: keeps error messages consistent and stops confused-looking
+    /// version specs from silently accepting an LFS flag.
+    #[test]
+    fn test_conda_lfs_without_git_rejected() {
+        let err = serde_json::from_value::<PixiSpec>(json!({
+            "version": "*",
+            "lfs": true,
+        }))
+        .expect_err("lfs without git should fail");
+        assert!(
+            err.to_string().contains("only valid when `git`"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/pixi_spec/src/toml.rs
+++ b/crates/pixi_spec/src/toml.rs
@@ -649,7 +649,7 @@ impl TomlSpec {
                         git,
                         rev,
                         subdirectory,
-                        lfs: loc.lfs.map(pixi_git::GitLfs::from),
+                        lfs: pixi_git::GitLfs::from(loc.lfs),
                     })
                 }
                 (None, None, None) => {
@@ -1168,7 +1168,7 @@ impl TomlLocationSpec {
                     git,
                     rev,
                     subdirectory,
-                    lfs: self.lfs.map(pixi_git::GitLfs::from),
+                    lfs: pixi_git::GitLfs::from(self.lfs),
                 })
             }
             (_, _, _) => return Err(SourceLocationSpecError::MultipleIdentifiers),
@@ -1661,7 +1661,7 @@ mod test {
         insta::assert_yaml_snapshot!(snapshot);
     }
 
-    /// `lfs = true` on a conda git spec parses into `GitSpec.lfs == Some(true)`
+    /// `lfs = true` on a conda git spec parses into `GitSpec.lfs == Enabled`
     /// so the downstream resolver can request LFS artifacts.
     #[test]
     fn test_conda_git_lfs_parses() {
@@ -1671,7 +1671,7 @@ mod test {
         }))
         .expect("parse should succeed");
         let git = spec.as_git().expect("expected a git spec");
-        assert_eq!(git.lfs, Some(pixi_git::GitLfs::Enabled));
+        assert_eq!(git.lfs, pixi_git::GitLfs::Enabled);
     }
 
     /// `lfs` without `git` is rejected the same way `branch` / `rev` / `tag`

--- a/crates/pixi_uv_conversions/src/conversions.rs
+++ b/crates/pixi_uv_conversions/src/conversions.rs
@@ -318,7 +318,7 @@ pub fn into_pixi_reference(git_reference: uv_git_types::GitReference) -> PixiRef
 pub fn into_pinned_git_spec(
     dist: GitSourceDist,
     original_reference: Option<PixiReference>,
-    original_lfs: Option<bool>,
+    original_lfs: Option<pixi_git::GitLfs>,
 ) -> PinnedGitSpec {
     // Necessary to convert between our gitsha and uv gitsha.
     let git_sha = PixiGitSha::from_str(

--- a/crates/pixi_uv_conversions/src/conversions.rs
+++ b/crates/pixi_uv_conversions/src/conversions.rs
@@ -312,9 +312,13 @@ pub fn into_pixi_reference(git_reference: uv_git_types::GitReference) -> PixiRef
 /// `?branch=/?tag=/?rev=` in sync with what the manifest's PEP 508 string
 /// actually says, so the satisfiability check matches without relying on the
 /// no-ref fallback.
+///
+/// `original_lfs` carries the manifest's `lfs = true/false` into the lock file
+/// (as a `?lfs=...` query pair); uv's `GitSourceDist` doesn't preserve it.
 pub fn into_pinned_git_spec(
     dist: GitSourceDist,
     original_reference: Option<PixiReference>,
+    original_lfs: Option<bool>,
 ) -> PinnedGitSpec {
     // Necessary to convert between our gitsha and uv gitsha.
     let git_sha = PixiGitSha::from_str(
@@ -335,7 +339,8 @@ pub fn into_pinned_git_spec(
             .and_then(|sd| pixi_spec::Subdirectory::try_from(sd.to_path_buf()).ok())
             .unwrap_or_default(),
         reference,
-    );
+    )
+    .with_lfs(original_lfs);
 
     // `url()` is the original URL; `repository()` is the canonical
     // (lowercased + `.git`-stripped) form that would corrupt the lockfile
@@ -373,7 +378,7 @@ pub fn to_parsed_git_url(
             },
             into_uv_git_reference(git_source.reference.into()),
             Some(into_uv_git_sha(git_source.commit)),
-            uv_git_types::GitLfs::Disabled,
+            crate::to_uv_git_lfs(git_source.lfs),
         )
         .into_diagnostic()?,
         if git_source.subdirectory.is_empty() {
@@ -902,7 +907,7 @@ mod tests {
             url: VerbatimUrl::from_url(safe_url),
         };
 
-        let pinned = into_pinned_git_spec(dist, None);
+        let pinned = into_pinned_git_spec(dist, None, None);
 
         assert_eq!(pinned.git.as_str(), original);
     }

--- a/crates/pixi_uv_conversions/src/conversions.rs
+++ b/crates/pixi_uv_conversions/src/conversions.rs
@@ -318,7 +318,7 @@ pub fn into_pixi_reference(git_reference: uv_git_types::GitReference) -> PixiRef
 pub fn into_pinned_git_spec(
     dist: GitSourceDist,
     original_reference: Option<PixiReference>,
-    original_lfs: Option<pixi_git::GitLfs>,
+    original_lfs: pixi_git::GitLfs,
 ) -> PinnedGitSpec {
     // Necessary to convert between our gitsha and uv gitsha.
     let git_sha = PixiGitSha::from_str(
@@ -907,7 +907,7 @@ mod tests {
             url: VerbatimUrl::from_url(safe_url),
         };
 
-        let pinned = into_pinned_git_spec(dist, None, None);
+        let pinned = into_pinned_git_spec(dist, None, pixi_git::GitLfs::Disabled);
 
         assert_eq!(pinned.git.as_str(), original);
     }

--- a/crates/pixi_uv_conversions/src/requirements.rs
+++ b/crates/pixi_uv_conversions/src/requirements.rs
@@ -55,10 +55,10 @@ fn create_uv_url(
 
 /// Map a pixi-side LFS preference (tri-state) to uv's binary enum. uv only
 /// distinguishes "fetch LFS" from "don't"; we treat `None` (env-default) the
-/// same as `Some(false)`, since uv does its own git checkout outside of
+/// same as `Some(Disabled)`, since uv does its own git checkout outside of
 /// `pixi_git`'s `PIXI_GIT_LFS` plumbing.
-pub fn to_uv_git_lfs(lfs: Option<bool>) -> uv_git_types::GitLfs {
-    if lfs == Some(true) {
+pub fn to_uv_git_lfs(lfs: Option<pixi_git::GitLfs>) -> uv_git_types::GitLfs {
+    if lfs == Some(pixi_git::GitLfs::Enabled) {
         uv_git_types::GitLfs::Enabled
     } else {
         uv_git_types::GitLfs::Disabled

--- a/crates/pixi_uv_conversions/src/requirements.rs
+++ b/crates/pixi_uv_conversions/src/requirements.rs
@@ -53,6 +53,18 @@ fn create_uv_url(
     url.parse()
 }
 
+/// Map a pixi-side LFS preference (tri-state) to uv's binary enum. uv only
+/// distinguishes "fetch LFS" from "don't"; we treat `None` (env-default) the
+/// same as `Some(false)`, since uv does its own git checkout outside of
+/// `pixi_git`'s `PIXI_GIT_LFS` plumbing.
+pub fn to_uv_git_lfs(lfs: Option<bool>) -> uv_git_types::GitLfs {
+    if lfs == Some(true) {
+        uv_git_types::GitLfs::Enabled
+    } else {
+        uv_git_types::GitLfs::Disabled
+    }
+}
+
 fn manifest_version_to_version_specifiers(
     version: &VersionOrStar,
 ) -> Result<VersionSpecifiers, uv_pep440::VersionSpecifiersParseError> {
@@ -112,6 +124,7 @@ pub fn as_uv_req(
                     git,
                     rev,
                     subdirectory,
+                    lfs,
                 },
         } => {
             let git_url = GitUrlWithPrefix::from(git);
@@ -132,7 +145,7 @@ pub fn as_uv_req(
                         .and_then(|s| s.map(uv_git_types::GitOid::from_str))
                         .transpose()
                         .expect("could not parse sha"),
-                    uv_git_types::GitLfs::Disabled,
+                    to_uv_git_lfs(*lfs),
                 )?,
                 subdirectory: if subdirectory.is_empty() {
                     None
@@ -363,6 +376,7 @@ mod tests {
                     "d099af3b1028b00c232d8eda28a997984ae5848b".to_string(),
                 )),
                 subdirectory: Default::default(),
+                lfs: None,
             },
         });
         let uv_req = as_uv_req(&pypi_req, "test", Path::new("")).unwrap();
@@ -391,6 +405,7 @@ mod tests {
                     "d099af3b1028b00c232d8eda28a997984ae5848b".to_string(),
                 )),
                 subdirectory: Default::default(),
+                lfs: None,
             },
         });
         let uv_req = as_uv_req(&pypi_req, "test", Path::new("")).unwrap();

--- a/crates/pixi_uv_conversions/src/requirements.rs
+++ b/crates/pixi_uv_conversions/src/requirements.rs
@@ -1,3 +1,4 @@
+use pixi_git::GitLfs;
 use pixi_pypi_spec::{PixiPypiSource, PixiPypiSpec, VersionOrStar};
 use pixi_spec::{GitReference, GitSpec};
 use rattler_lock::UrlOrPath;
@@ -53,12 +54,11 @@ fn create_uv_url(
     url.parse()
 }
 
-/// Map a pixi-side LFS preference (tri-state) to uv's binary enum. uv only
-/// distinguishes "fetch LFS" from "don't"; we treat `None` (env-default) the
-/// same as `Some(Disabled)`, since uv does its own git checkout outside of
-/// `pixi_git`'s `PIXI_GIT_LFS` plumbing.
-pub fn to_uv_git_lfs(lfs: Option<pixi_git::GitLfs>) -> uv_git_types::GitLfs {
-    if lfs == Some(pixi_git::GitLfs::Enabled) {
+/// Map pixi's [`GitLfs`] policy to uv's [`uv_git_types::GitLfs`]. Both are
+/// binary; the env-var fallback was resolved on the pixi side at
+/// manifest-input time.
+pub fn to_uv_git_lfs(lfs: GitLfs) -> uv_git_types::GitLfs {
+    if lfs.is_enabled() {
         uv_git_types::GitLfs::Enabled
     } else {
         uv_git_types::GitLfs::Disabled
@@ -376,7 +376,7 @@ mod tests {
                     "d099af3b1028b00c232d8eda28a997984ae5848b".to_string(),
                 )),
                 subdirectory: Default::default(),
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         });
         let uv_req = as_uv_req(&pypi_req, "test", Path::new("")).unwrap();
@@ -405,7 +405,7 @@ mod tests {
                     "d099af3b1028b00c232d8eda28a997984ae5848b".to_string(),
                 )),
                 subdirectory: Default::default(),
-                lfs: None,
+                lfs: GitLfs::Disabled,
             },
         });
         let uv_req = as_uv_req(&pypi_req, "test", Path::new("")).unwrap();

--- a/docs/reference/pixi_manifest.md
+++ b/docs/reference/pixi_manifest.md
@@ -988,13 +988,19 @@ Use `git` in combination with `rev` or `subdirectory`:
 
 - `rev`: A specific revision to install. e.g. `rev = "0106aced5faa299e6ede89d1230bd6784f2c3660`
 - `subdirectory`: A subdirectory to install from. `subdirectory = "src"` or `subdirectory = "src/packagex"`
+- `lfs`: Fetch git LFS objects (e.g. data tracked with [git-lfs](https://git-lfs.com/)) when checking out the repo. Defaults to off. When unset, Pixi honours the `PIXI_GIT_LFS` environment variable.
 
 ```toml
 # Note don't forget the `ssh://` or `https://` prefix!
 pytest = { git = "https://github.com/pytest-dev/pytest.git"}
 httpx = { git = "https://github.com/encode/httpx.git", rev = "c7c13f18a5af4c64c649881b2fe8dbd72a519c32"}
 py-rattler = { git = "ssh://git@github.com/conda/rattler.git", subdirectory = "py-rattler" }
+# Materialise LFS-tracked files instead of leaving them as pointer files
+lfs-example = { git = "https://github.com/foo/lfs-repo.git", lfs = true }
 ```
+
+!!! note "Requires `git-lfs`"
+    Setting `lfs = true` requires the `git-lfs` executable on `PATH`. Install it with your system package manager (or `pixi global install git-lfs`).
 
 ##### `path`
 

--- a/docs/reference/pixi_manifest.md
+++ b/docs/reference/pixi_manifest.md
@@ -988,7 +988,7 @@ Use `git` in combination with `rev` or `subdirectory`:
 
 - `rev`: A specific revision to install. e.g. `rev = "0106aced5faa299e6ede89d1230bd6784f2c3660`
 - `subdirectory`: A subdirectory to install from. `subdirectory = "src"` or `subdirectory = "src/packagex"`
-- `lfs`: Fetch git LFS objects (e.g. data tracked with [git-lfs](https://git-lfs.com/)) when checking out the repo. Defaults to off. When unset, Pixi honours the `PIXI_GIT_LFS` environment variable.
+- `lfs`: Fetch git LFS objects (e.g. data tracked with [git-lfs](https://git-lfs.com/)) when checking out the repo. Defaults to off when unset.
 
 ```toml
 # Note don't forget the `ssh://` or `https://` prefix!

--- a/schema/model.py
+++ b/schema/model.py
@@ -310,6 +310,10 @@ class MatchspecTable(StrictBaseModel):
     tag: NonEmptyStr | None = Field(None, description="A git tag to use")
     branch: NonEmptyStr | None = Field(None, description="A git branch to use")
     subdirectory: NonEmptyStr | None = Field(None, description="A subdirectory to use in the repo")
+    lfs: bool | None = Field(
+        None,
+        description="Fetch git LFS objects when checking out this repo. Defaults to the `PIXI_GIT_LFS` env var.",
+    )
 
 
 class SourceSpecTable(StrictBaseModel):
@@ -326,6 +330,10 @@ class SourceSpecTable(StrictBaseModel):
     tag: NonEmptyStr | None = Field(None, description="A git tag to use")
     branch: NonEmptyStr | None = Field(None, description="A git branch to use")
     subdirectory: NonEmptyStr | None = Field(None, description="A subdirectory to use in the repo")
+    lfs: bool | None = Field(
+        None,
+        description="Fetch git LFS objects when checking out this repo. Defaults to the `PIXI_GIT_LFS` env var.",
+    )
 
 
 class WhenAll(StrictBaseModel):
@@ -421,6 +429,10 @@ class _PyPiGitRequirement(_PyPIRequirement):
     )
     subdirectory: NonEmptyStr | None = Field(
         None, description="The subdirectory in the repo, a path from the root of the repo."
+    )
+    lfs: bool | None = Field(
+        None,
+        description="Fetch git LFS objects when checking out this repo. Defaults to the `PIXI_GIT_LFS` env var.",
     )
 
 
@@ -974,6 +986,10 @@ class SourceLocation(StrictBaseModel):
     tag: NonEmptyStr | None = Field(None, description="A git tag to use")
     branch: NonEmptyStr | None = Field(None, description="A git branch to use")
     subdirectory: NonEmptyStr | None = Field(None, description="A subdirectory to use in the repo")
+    lfs: bool | None = Field(
+        None,
+        description="Fetch git LFS objects when checking out this repo. Defaults to the `PIXI_GIT_LFS` env var.",
+    )
 
 
 class Build(StrictBaseModel):


### PR DESCRIPTION
## Summary

Extends `GitSpec` with `lfs: Option<bool>` so the manifest can opt into git LFS fetching for both **pypi** and **conda** git dependencies:

```toml
[pypi-dependencies]
myrepo = { git = "https://github.com/foo/myrepo.git", lfs = true }

[dependencies]
mypkg = { git = "https://github.com/foo/conda-src.git", lfs = true }
```

The flag flows through both code paths:

- **Conda source dependencies** (`pixi_git` resolver) — gain LFS via the existing `GitSource::with_lfs` plumbing from #6183, threaded through `CheckoutGit` and a new `lfs` parameter on `GitResolver::fetch`. The `CheckoutGit` dedup key includes the lfs flag so two callers asking for the same commit with different lfs preferences get distinct compute futures (the on-disk DB is still shared via `GitResolver`'s path-based lock).
- **PyPI dependencies** — `lfs = true` now maps to `uv_git_types::GitLfs::Enabled` at every `GitUrl::from_fields` call site in `pixi_uv_conversions`, replacing the previously hard-coded `Disabled`. A new `to_uv_git_lfs(Option<bool>)` helper centralises the conversion.

### Lock file round-trip

The flag round-trips through the lock file as a `?lfs=true` query pair on the locked git URL. `PinnedGitCheckout` gains an `lfs: Option<bool>` field; `into_locked_git_url` writes it and `from_locked_url` reads it back. `None` (the default) is omitted from the URL to avoid churning lock files for projects that don't use LFS.

This matters because `GitSource::fetch`'s cache-hit branch additionally checks `db.contains_lfs_artifacts` when LFS was requested — without persisting the flag, reinstalls from a warm cache could silently skip the LFS validation.

### Validation

`lfs` without `git` is rejected the same way `branch` / `rev` / `tag` are. Error messages and snapshots updated accordingly.

### Scope notes

- The build-backend boundary type `pixi_build_types::GitSpec` is unchanged: build backends receive an already-checked-out source path, so they don't need to know about LFS.
- No CLI flag (`pixi add --lfs`) for now — for pypi the PEP 508 vcs-requirement format can't carry it, so supporting it only for conda would be confusing. Manifest editing is the primary path.
- Fixes prefix-dev/pixi#2000.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo test -p pixi_spec --features rattler_lock` — added `test_conda_git_lfs_parses` and `test_conda_lfs_without_git_rejected`
- [x] `cargo test -p pixi_pypi_spec --features pixi_spec/rattler_lock` — added `test_deserialize_pypi_from_git_lfs`, `test_deserialize_pypi_from_git_lfs_false`, `test_deserialize_pypi_lfs_without_git_fails`; updated `deserialize_fail_on_unknown` snapshot
- [x] `cargo test -p pixi_record` — added `test_pinned_git_lfs_roundtrip` and `test_pinned_git_no_lfs_does_not_serialize` to cover the locked-URL query-pair round-trip
- [x] `cargo test -p pixi_compute_sources` — added `pin_and_checkout_git_with_lfs` integration test against the existing `lfs-sample` fixture (skipped when `git-lfs` is unavailable)
- [ ] End-to-end: lock and install a real LFS-tracked pypi git dep on a machine with `git-lfs` installed (relies on uv 0.11.15's LFS plumbing)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VTvw7AoFvh7QnrLqHjbudZ)_