### PR TITLE
feat: skip satisfiability checking when workspace inputs are unchanged (experimental)

### DIFF
--- a/crates/pixi/tests/integration_rust/input_fingerprint_tests.rs
+++ b/crates/pixi/tests/integration_rust/input_fingerprint_tests.rs
@@ -1,0 +1,278 @@
+//! Integration tests for the experimental workspace input fingerprint
+//! (`[experimental] use-workspace-freshness-cache`) and the fast-path gate in
+//! `Workspace::update_lock_file`.
+//!
+//! All tests run offline against a materialized `MockRepoData` channel.
+
+use std::path::PathBuf;
+
+use pixi_test_utils::{MockRepoData, Package};
+use rattler_conda_types::Platform;
+
+use crate::common::{LockFileExt, PixiControl};
+use crate::setup_tracing;
+
+/// The probe kinds a v1 fingerprint must record.
+const EXPECTED_PROBE_KINDS: [&str; 5] = [
+    "manifest-file-content",
+    "resolved-config",
+    "lock-file-content",
+    "env-vars",
+    "pixi-version",
+];
+
+/// Enables the experimental freshness cache in the workspace-local
+/// `.pixi/config.toml` that `PixiControl::new` seeds (appending, not
+/// clobbering, so the default local channel configuration survives).
+fn enable_freshness_cache(pixi: &PixiControl) {
+    let config_path = pixi.workspace_path().join(".pixi").join("config.toml");
+    let mut contents = fs_err::read_to_string(&config_path).unwrap_or_default();
+    contents.push_str("\n[experimental]\nuse-workspace-freshness-cache = true\n");
+    fs_err::write(&config_path, contents).unwrap();
+}
+
+/// The path of the workspace fingerprint marker.
+fn marker_path(pixi: &PixiControl) -> PathBuf {
+    pixi.workspace_path()
+        .join(".pixi")
+        .join("freshness")
+        .join("workspace.json")
+}
+
+/// Parses the marker and returns the digest recorded for the probe with the
+/// given kind.
+fn probe_digest(marker: &serde_json::Value, kind: &str) -> String {
+    marker["probes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|probe| probe["kind"] == kind)
+        .unwrap_or_else(|| panic!("marker should contain a `{kind}` probe"))["digest"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+/// Creates an offline channel with materialized `foo` and `bar` packages for
+/// the current platform.
+async fn materialized_channel() -> pixi_test_utils::LocalChannel {
+    let mut database = MockRepoData::default();
+    database.add_package(
+        Package::build("foo", "1.0.0")
+            .with_subdir(Platform::current())
+            .with_materialize(true)
+            .finish(),
+    );
+    database.add_package(
+        Package::build("bar", "1.0.0")
+            .with_subdir(Platform::current())
+            .with_materialize(true)
+            .finish(),
+    );
+    database.into_channel().await.unwrap()
+}
+
+/// A `pixi install` with the flag enabled records the fingerprint marker with
+/// the expected probes.
+#[tokio::test(flavor = "multi_thread")]
+async fn install_records_input_fingerprint() {
+    setup_tracing();
+    let channel = materialized_channel().await;
+
+    let pixi = PixiControl::from_manifest(&format!(
+        r#"
+        [workspace]
+        name = "fingerprint-install"
+        channels = ["{channel}"]
+        platforms = ["{platform}"]
+
+        [dependencies]
+        foo = "*"
+        "#,
+        channel = channel.url(),
+        platform = Platform::current(),
+    ))
+    .unwrap();
+    enable_freshness_cache(&pixi);
+
+    pixi.install().await.unwrap();
+
+    // The marker exists and records exactly the v1 probes.
+    let marker_bytes = fs_err::read(marker_path(&pixi)).unwrap();
+    let marker: serde_json::Value = serde_json::from_slice(&marker_bytes).unwrap();
+    assert_eq!(marker["schema_version"], 1);
+    let kinds: Vec<&str> = marker["probes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|probe| probe["kind"].as_str().unwrap())
+        .collect();
+    assert_eq!(kinds, EXPECTED_PROBE_KINDS);
+
+    // The lock file exists, so its digest must be a real digest, not the
+    // absent sentinel.
+    let lock_digest = probe_digest(&marker, "lock-file-content");
+    assert_eq!(lock_digest.len(), 16);
+    assert!(lock_digest.chars().all(|c| c.is_ascii_hexdigit()));
+
+    // The env-vars probe always pins PIXI_OVERRIDE_PLATFORM.
+    let env_probe = marker["probes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|probe| probe["kind"] == "env-vars")
+        .unwrap();
+    assert!(
+        env_probe["vars"]
+            .as_object()
+            .unwrap()
+            .contains_key("PIXI_OVERRIDE_PLATFORM")
+    );
+}
+
+/// With a fresh fingerprint, a second `update_lock_file` succeeds and leaves
+/// the lock file untouched (the gate skips the outdated walk; behavior stays
+/// identical to the slow path).
+#[tokio::test(flavor = "multi_thread")]
+async fn second_update_hits_the_gate_and_keeps_the_lock_file() {
+    setup_tracing();
+    let channel = materialized_channel().await;
+
+    let pixi = PixiControl::new().unwrap();
+    enable_freshness_cache(&pixi);
+    pixi.init()
+        .with_local_channel(channel.url().to_file_path().unwrap())
+        .await
+        .unwrap();
+    pixi.add("foo").await.unwrap();
+
+    // First update reaches steady state and records the fingerprint.
+    let lock = pixi.update_lock_file().await.unwrap();
+    assert!(lock.contains_conda_package("default", Platform::current(), "foo"));
+    assert!(marker_path(&pixi).is_file());
+    let lock_bytes_before = fs_err::read(pixi.workspace_path().join("pixi.lock")).unwrap();
+    let marker_before = fs_err::read(marker_path(&pixi)).unwrap();
+
+    // Second update: inputs unchanged, must succeed and not touch the lock.
+    let lock = pixi.update_lock_file().await.unwrap();
+    assert!(lock.contains_conda_package("default", Platform::current(), "foo"));
+    let lock_bytes_after = fs_err::read(pixi.workspace_path().join("pixi.lock")).unwrap();
+    assert_eq!(
+        lock_bytes_before, lock_bytes_after,
+        "a no-op update must not rewrite the lock file"
+    );
+
+    // The marker still validates against the same inputs (content equal).
+    let marker_after = fs_err::read(marker_path(&pixi)).unwrap();
+    assert_eq!(marker_before, marker_after);
+}
+
+/// Editing the manifest makes the fingerprint stale: the next update
+/// re-solves correctly and re-records the marker with a new manifest digest.
+#[tokio::test(flavor = "multi_thread")]
+async fn manifest_edit_invalidates_and_rerecords_the_fingerprint() {
+    setup_tracing();
+    let channel = materialized_channel().await;
+
+    let pixi = PixiControl::new().unwrap();
+    enable_freshness_cache(&pixi);
+    pixi.init()
+        .with_local_channel(channel.url().to_file_path().unwrap())
+        .await
+        .unwrap();
+    pixi.add("foo").await.unwrap();
+    pixi.update_lock_file().await.unwrap();
+
+    let marker: serde_json::Value =
+        serde_json::from_slice(&fs_err::read(marker_path(&pixi)).unwrap()).unwrap();
+    let manifest_digest_before = probe_digest(&marker, "manifest-file-content");
+    let lock_digest_before = probe_digest(&marker, "lock-file-content");
+
+    // Edit the manifest (pixi add rewrites pixi.toml and re-solves).
+    pixi.add("bar").await.unwrap();
+
+    // The re-solve happened even though a (stale) fingerprint existed.
+    let lock = pixi.update_lock_file().await.unwrap();
+    assert!(
+        lock.contains_conda_package("default", Platform::current(), "bar"),
+        "the manifest edit must lead to a re-solve that locks `bar`"
+    );
+
+    // The marker was re-recorded with new digests.
+    let marker: serde_json::Value =
+        serde_json::from_slice(&fs_err::read(marker_path(&pixi)).unwrap()).unwrap();
+    assert_eq!(marker["schema_version"], 1);
+    let manifest_digest_after = probe_digest(&marker, "manifest-file-content");
+    let lock_digest_after = probe_digest(&marker, "lock-file-content");
+    assert_ne!(
+        manifest_digest_before, manifest_digest_after,
+        "the manifest digest must change after editing the manifest"
+    );
+    assert_ne!(
+        lock_digest_before, lock_digest_after,
+        "the lock digest must change after a re-solve"
+    );
+}
+
+/// A corrupt marker never breaks an update: pixi falls through to the normal
+/// path and rewrites a valid marker.
+#[tokio::test(flavor = "multi_thread")]
+async fn corrupt_marker_falls_back_and_is_rewritten() {
+    setup_tracing();
+    let channel = materialized_channel().await;
+
+    let pixi = PixiControl::new().unwrap();
+    enable_freshness_cache(&pixi);
+    pixi.init()
+        .with_local_channel(channel.url().to_file_path().unwrap())
+        .await
+        .unwrap();
+    pixi.add("foo").await.unwrap();
+    pixi.update_lock_file().await.unwrap();
+    assert!(marker_path(&pixi).is_file());
+
+    // Corrupt the marker.
+    fs_err::write(marker_path(&pixi), b"{ this is not json").unwrap();
+    let lock_bytes_before = fs_err::read(pixi.workspace_path().join("pixi.lock")).unwrap();
+
+    // The update still works and does not touch the lock file.
+    let lock = pixi.update_lock_file().await.unwrap();
+    assert!(lock.contains_conda_package("default", Platform::current(), "foo"));
+    let lock_bytes_after = fs_err::read(pixi.workspace_path().join("pixi.lock")).unwrap();
+    assert_eq!(lock_bytes_before, lock_bytes_after);
+
+    // The marker was rewritten and is valid JSON again.
+    let marker: serde_json::Value =
+        serde_json::from_slice(&fs_err::read(marker_path(&pixi)).unwrap()).unwrap();
+    assert_eq!(marker["schema_version"], 1);
+}
+
+/// With the flag off (the default), no marker is ever written.
+#[tokio::test(flavor = "multi_thread")]
+async fn flag_off_never_writes_a_marker() {
+    setup_tracing();
+    let channel = materialized_channel().await;
+
+    let pixi = PixiControl::new().unwrap();
+    // Note: deliberately NOT enabling the flag.
+    pixi.init()
+        .with_local_channel(channel.url().to_file_path().unwrap())
+        .await
+        .unwrap();
+    pixi.add("foo").await.unwrap();
+    pixi.update_lock_file().await.unwrap();
+    pixi.update_lock_file().await.unwrap();
+
+    assert!(
+        !marker_path(&pixi).exists(),
+        "no fingerprint marker may be written when the flag is off"
+    );
+    assert!(
+        !pixi
+            .workspace_path()
+            .join(".pixi")
+            .join("freshness")
+            .exists(),
+        "the freshness directory must not be created when the flag is off"
+    );
+}

--- a/crates/pixi/tests/integration_rust/main.rs
+++ b/crates/pixi/tests/integration_rust/main.rs
@@ -5,6 +5,7 @@ mod common;
 mod develop_dependencies_tests;
 mod global_tests;
 mod init_tests;
+mod input_fingerprint_tests;
 mod install_filter_tests;
 mod install_tests;
 mod lock_tests;

--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -1058,6 +1058,15 @@ pub struct ExperimentalConfig {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_environment_activation_cache: Option<bool>,
+
+    /// The option to opt into the workspace freshness cache: a workspace-scoped
+    /// input fingerprint that lets pixi skip the lock-file up-to-date check
+    /// when none of the inputs changed since the last successful run.
+    /// This is an experimental feature and may be removed in the future or made
+    /// default.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub use_workspace_freshness_cache: Option<bool>,
 }
 
 impl ExperimentalConfig {
@@ -1066,14 +1075,24 @@ impl ExperimentalConfig {
             use_environment_activation_cache: other
                 .use_environment_activation_cache
                 .or(self.use_environment_activation_cache),
+            use_workspace_freshness_cache: other
+                .use_workspace_freshness_cache
+                .or(self.use_workspace_freshness_cache),
         }
     }
     pub fn use_environment_activation_cache(&self) -> bool {
         self.use_environment_activation_cache.unwrap_or(false)
     }
 
+    /// Returns true if the workspace freshness cache is enabled. Defaults to
+    /// `false` when unset.
+    pub fn use_workspace_freshness_cache(&self) -> bool {
+        self.use_workspace_freshness_cache.unwrap_or(false)
+    }
+
     pub fn is_default(&self) -> bool {
         self.use_environment_activation_cache.is_none()
+            && self.use_workspace_freshness_cache.is_none()
     }
 }
 
@@ -1547,6 +1566,7 @@ impl From<ConfigCli> for Config {
                 } else {
                     None
                 },
+                use_workspace_freshness_cache: None,
             },
             pinning_strategy: cli.pinning_strategy,
             allow_symbolic_links: cli.no_symbolic_links.then_some(false),
@@ -2102,6 +2122,7 @@ impl Config {
             "detached-environments",
             "experimental",
             "experimental.use-environment-activation-cache",
+            "experimental.use-workspace-freshness-cache",
             "mirrors",
             "pinning-strategy",
             "proxy-config",
@@ -2266,6 +2287,13 @@ impl Config {
 
     pub fn experimental_activation_cache_usage(&self) -> bool {
         self.experimental.use_environment_activation_cache()
+    }
+
+    /// Returns true if the experimental workspace freshness cache (a
+    /// workspace-scoped input fingerprint used to skip the lock-file
+    /// up-to-date check) is enabled.
+    pub fn experimental_workspace_freshness_cache_usage(&self) -> bool {
+        self.experimental.use_workspace_freshness_cache()
     }
 
     /// Retrieve the value for the max_concurrent_solves field.
@@ -2545,6 +2573,10 @@ impl Config {
                 match subkey {
                     "use-environment-activation-cache" => {
                         self.experimental.use_environment_activation_cache =
+                            value.map(|v| v.parse()).transpose().into_diagnostic()?;
+                    }
+                    "use-workspace-freshness-cache" => {
+                        self.experimental.use_workspace_freshness_cache =
                             value.map(|v| v.parse()).transpose().into_diagnostic()?;
                     }
                     _ => return Err(err),
@@ -3083,6 +3115,7 @@ UNUSED = "unused"
             pinning_strategy: Some(PinningStrategy::NoPin),
             experimental: ExperimentalConfig {
                 use_environment_activation_cache: Some(true),
+                use_workspace_freshness_cache: None,
             },
             loaded_from: Vec::from([PathBuf::from_str("test").unwrap()]),
             shell: ShellConfig {
@@ -4257,5 +4290,62 @@ UNUSED = "unused"
         };
         let err = config.validate().unwrap_err();
         assert!(format!("{err}").contains("cache.conda-packages"));
+    }
+
+    #[test]
+    fn test_workspace_freshness_cache_config() {
+        // Default: the flag is off and the experimental section counts as
+        // default.
+        let config = Config::default();
+        assert!(!config.experimental_workspace_freshness_cache_usage());
+        assert!(config.experimental.is_default());
+
+        // TOML parsing.
+        let toml = "[experimental]\nuse-workspace-freshness-cache = true";
+        let (config, _) = Config::from_toml(toml, None).unwrap();
+        assert_eq!(
+            config.experimental.use_workspace_freshness_cache,
+            Some(true)
+        );
+        assert!(config.experimental_workspace_freshness_cache_usage());
+        assert!(!config.experimental.is_default());
+
+        // `pixi config set` handler sets and unsets the key.
+        let mut config = Config::default();
+        config
+            .set(
+                "experimental.use-workspace-freshness-cache",
+                Some("true".to_string()),
+            )
+            .unwrap();
+        assert_eq!(
+            config.experimental.use_workspace_freshness_cache,
+            Some(true)
+        );
+        config
+            .set("experimental.use-workspace-freshness-cache", None)
+            .unwrap();
+        assert_eq!(config.experimental.use_workspace_freshness_cache, None);
+
+        // Merging: `other` takes precedence over `self`, `None` keeps `self`.
+        let low = ExperimentalConfig {
+            use_workspace_freshness_cache: Some(false),
+            ..ExperimentalConfig::default()
+        };
+        let high = ExperimentalConfig {
+            use_workspace_freshness_cache: Some(true),
+            ..ExperimentalConfig::default()
+        };
+        let merged = low.clone().merge(high);
+        assert_eq!(merged.use_workspace_freshness_cache, Some(true));
+        let merged = low.merge(ExperimentalConfig::default());
+        assert_eq!(merged.use_workspace_freshness_cache, Some(false));
+
+        // The key is discoverable through `get_keys`.
+        assert!(
+            Config::default()
+                .get_keys()
+                .contains(&"experimental.use-workspace-freshness-cache")
+        );
     }
 }

--- a/crates/pixi_config/src/snapshots/pixi_config__tests__config_merge_multiple.snap
+++ b/crates/pixi_config/src/snapshots/pixi_config__tests__config_merge_multiple.snap
@@ -127,6 +127,7 @@ Config {
     },
     experimental: ExperimentalConfig {
         use_environment_activation_cache: None,
+        use_workspace_freshness_cache: None,
     },
     concurrency: ConcurrencyConfig {
         solves: 1,

--- a/crates/pixi_core/src/lock_file/freshness/mod.rs
+++ b/crates/pixi_core/src/lock_file/freshness/mod.rs
@@ -1,0 +1,536 @@
+//! Workspace-scoped "inputs unchanged" freshness fingerprint.
+//!
+//! This module implements the L0→L1 edge of the unified freshness model: a
+//! recorded, re-checkable trace of every input that feeds lock-file
+//! resolution (manifest bytes, resolved config, lock bytes, override
+//! environment variables, pixi version). When a previously recorded
+//! fingerprint validates against the current inputs,
+//! [`Workspace::update_lock_file`](crate::Workspace::update_lock_file) can
+//! skip building the lock-file resolver and the whole outdated/satisfiability
+//! walk.
+//!
+//! The feature is experimental and gated behind the
+//! `[experimental] use-workspace-freshness-cache` configuration flag
+//! (default off).
+//!
+//! Layering:
+//! * [`probe`] — the pure probe model. Computation and validation are pure
+//!   functions over a [`FingerprintInputs`] snapshot; no `Workspace`, no IO,
+//!   no process-global state.
+//! * [`store`] — atomic marker IO under `.pixi/freshness/`.
+//! * this file — thin glue that adapts a [`Workspace`] to the pure model.
+//!
+//! Correctness stance: every failure mode (missing marker, corrupt marker,
+//! unknown probe kind, unreadable input) degrades to the slow path, never to
+//! trusting a stale environment. Fingerprints are only recorded after the
+//! lock file has been proven up-to-date or freshly written, and — conservative
+//! v1 — never when the lock file contains source packages, whose freshness
+//! additionally depends on source files that v1 does not probe.
+//!
+//! # Known v1 limitations (flag is default-off and experimental)
+//!
+//! * **In-memory manifest edits.** The manifest probe hashes the manifest
+//!   file *on disk*. Flows that mutate the manifest in memory and call
+//!   `update_lock_file` before saving (the `WorkspaceMut`-based
+//!   channel/platform commands in `pixi_api`) can therefore validate a
+//!   fingerprint that does not describe the manifest being resolved: the
+//!   in-flight command may skip a required re-solve (self-heals on the next
+//!   invocation once the manifest is saved), and a marker recorded before a
+//!   failed save binds the old manifest to the new lock. Fixing this needs
+//!   the `Workspace` to expose the bytes it was actually parsed from —
+//!   planned alongside the LazyLockFile rework of this region.
+//! * **TOCTOU on record.** Inputs are re-read from disk at record time, a
+//!   moment after they were proven; a concurrent external edit in that window
+//!   is attested. The window is milliseconds and requires an external writer
+//!   racing pixi.
+//! * **Path source archives.** A pypi path dependency recorded while its
+//!   location is not a directory (e.g. an sdist archive, or a not-yet
+//!   materialized submodule) does not block recording; if that path later
+//!   becomes a directory without any other input changing, the gate can skip
+//!   the check that would inspect it. FileSet probes (round 2) own this.
+
+mod probe;
+mod store;
+
+use std::path::{Path, PathBuf};
+
+use pixi_consts::consts;
+use rattler_lock::{LockFile, LockedPackage, UrlOrPath};
+use thiserror::Error;
+
+// The deliberate public surface of the freshness module: the two
+// `update_lock_file` entry points plus the check result (whose `Stale`
+// variant carries a `StaleReason`). Everything else — the probe model, the
+// marker store, the raw evaluate/collect primitives — stays module-internal
+// so the on-disk format and layering can evolve without breaking consumers.
+use probe::{FingerprintInputs, WorkspaceFingerprint, collect_override_env_vars, evaluate_marker};
+pub use probe::{FreshnessCheck, StaleReason};
+
+use crate::Workspace;
+use crate::environment::LockFileUsage;
+
+/// Errors that can occur while gathering inputs or persisting the marker.
+///
+/// These are internal to the fast path: callers treat them as "no fast path"
+/// (checks degrade to stale, recording is skipped with a debug log), so they
+/// never surface as user-visible failures. The underlying error is embedded
+/// in the message because these are only ever consumed via `Display` in
+/// debug logs.
+#[derive(Debug, Error)]
+pub(crate) enum FreshnessError {
+    /// A required input file could not be read.
+    #[error("failed to read {what} at `{path}`: {source}")]
+    ReadInput {
+        /// What was being read (for diagnostics).
+        what: &'static str,
+        /// The path that failed to read.
+        path: PathBuf,
+        /// The underlying IO error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// A value could not be serialized to JSON.
+    #[error("failed to serialize {what}: {source}")]
+    Serialize {
+        /// What was being serialized (for diagnostics).
+        what: &'static str,
+        /// The underlying serde error.
+        #[source]
+        source: serde_json::Error,
+    },
+
+    /// The marker file could not be written.
+    #[error("failed to write the freshness marker at `{path}`: {source}")]
+    WriteMarker {
+        /// The path that failed to write.
+        path: PathBuf,
+        /// The underlying IO error.
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+/// Returns the path of the workspace fingerprint marker for `workspace`:
+/// `<workspace>/.pixi/freshness/workspace.json`.
+///
+/// Deliberately anchored at the workspace's default `.pixi` directory (not a
+/// detached-environments directory): the marker describes the workspace's
+/// inputs and belongs next to them. On workspaces where `.pixi` is not
+/// writable the marker write fails softly and the feature simply never
+/// engages.
+fn workspace_fingerprint_path(workspace: &Workspace) -> PathBuf {
+    store::fingerprint_path(&workspace.default_pixi_dir())
+}
+
+/// Serializes the resolved configuration to canonical JSON bytes suitable
+/// for digesting.
+///
+/// `Config` contains `HashMap` fields (mirrors, s3-options) whose iteration
+/// order is randomized per instance, so a direct `serde_json::to_vec` would
+/// produce different bytes on every run — the `resolved-config` digest would
+/// then never match and the fast path would silently never engage for users
+/// of those settings. Round-tripping through [`serde_json::Value`] with an
+/// explicit recursive key sort produces stable bytes regardless of the
+/// source map type and regardless of whether serde_json's `preserve_order`
+/// feature is enabled somewhere in the dependency graph.
+fn canonical_config_json(config: &pixi_config::Config) -> Result<Vec<u8>, serde_json::Error> {
+    fn sort_keys(value: serde_json::Value) -> serde_json::Value {
+        match value {
+            serde_json::Value::Object(map) => {
+                let mut entries: Vec<(String, serde_json::Value)> = map
+                    .into_iter()
+                    .map(|(key, value)| (key, sort_keys(value)))
+                    .collect();
+                entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+                serde_json::Value::Object(entries.into_iter().collect())
+            }
+            serde_json::Value::Array(items) => {
+                serde_json::Value::Array(items.into_iter().map(sort_keys).collect())
+            }
+            other => other,
+        }
+    }
+
+    serde_json::to_value(config).and_then(|value| serde_json::to_vec(&sort_keys(value)))
+}
+
+/// Gathers the current values of every input covered by the v1 probes.
+async fn gather_inputs(workspace: &Workspace) -> Result<FingerprintInputs, FreshnessError> {
+    let manifest_path = workspace.workspace.provenance.absolute_path();
+    let manifest_bytes = fs_err::tokio::read(&manifest_path)
+        .await
+        .map_err(|source| FreshnessError::ReadInput {
+            what: "the workspace manifest",
+            path: manifest_path.clone(),
+            source,
+        })?;
+
+    let config_json =
+        canonical_config_json(workspace.config()).map_err(|source| FreshnessError::Serialize {
+            what: "the resolved configuration",
+            source,
+        })?;
+
+    let lock_file_path = workspace.lock_file_path();
+    let lock_file_bytes = match fs_err::tokio::read(&lock_file_path).await {
+        Ok(bytes) => Some(bytes),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => None,
+        Err(source) => {
+            return Err(FreshnessError::ReadInput {
+                what: "the lock file",
+                path: lock_file_path,
+                source,
+            });
+        }
+    };
+
+    let override_env_vars = collect_override_env_vars(std::env::vars_os().map(|(name, value)| {
+        (
+            name.to_string_lossy().into_owned(),
+            value.to_string_lossy().into_owned(),
+        )
+    }));
+
+    Ok(FingerprintInputs {
+        manifest_path: manifest_path.to_string_lossy().into_owned(),
+        manifest_bytes,
+        config_json,
+        lock_file_bytes,
+        override_env_vars,
+        pixi_version: consts::PIXI_VERSION.to_string(),
+    })
+}
+
+/// Evaluates the on-disk workspace fingerprint against the current inputs.
+///
+/// Self-guarding: when the experimental flag is off this returns
+/// [`FreshnessCheck::Absent`] without touching the disk, so no caller can
+/// accidentally honor a marker for a user who has opted out.
+///
+/// Never fails: a missing or corrupt marker is [`FreshnessCheck::Absent`] and
+/// an unreadable input is [`FreshnessCheck::Stale`], both of which callers
+/// treat as "take the slow path".
+pub async fn check_workspace_freshness(workspace: &Workspace) -> FreshnessCheck {
+    if !workspace
+        .config()
+        .experimental_workspace_freshness_cache_usage()
+    {
+        return FreshnessCheck::Absent;
+    }
+
+    let marker_path = workspace_fingerprint_path(workspace);
+    let Some(marker_bytes) = store::read_marker_bytes(&marker_path).await else {
+        return FreshnessCheck::Absent;
+    };
+
+    let inputs = match gather_inputs(workspace).await {
+        Ok(inputs) => inputs,
+        Err(err) => {
+            return FreshnessCheck::Stale(StaleReason::InputUnavailable {
+                reason: err.to_string(),
+            });
+        }
+    };
+
+    evaluate_marker(Some(&marker_bytes), &inputs)
+}
+
+/// Records the workspace input fingerprint after a successful lock-file
+/// check or update.
+///
+/// This function is the single owner of the record-eligibility predicate;
+/// callers pass the flow facts (`lock_file_usage` and whether the on-disk
+/// lock file still uses an old format) instead of pre-filtering. Recording
+/// is skipped when:
+/// * the experimental flag is off,
+/// * the on-disk lock file needs a format upgrade (a marker would let the
+///   next run fast-path past the upgrade),
+/// * the run is a dry run (the on-disk lock file does not match the result),
+/// * the lock file contains source packages (conda source packages on any
+///   platform, or pypi path dependencies resolving to a directory) — their
+///   freshness depends on source files that v1 does not probe.
+///
+/// Best effort and non-fatal by design: failures are logged at debug level
+/// and otherwise ignored (the only consequence is that the next run takes
+/// the slow path).
+pub async fn record_workspace_freshness(
+    workspace: &Workspace,
+    lock_file: &LockFile,
+    lock_file_usage: LockFileUsage,
+    needs_format_upgrade: bool,
+) {
+    if !workspace
+        .config()
+        .experimental_workspace_freshness_cache_usage()
+    {
+        return;
+    }
+
+    if needs_format_upgrade || lock_file_usage == LockFileUsage::DryRun {
+        return;
+    }
+
+    if lock_file_contains_source_packages(lock_file, workspace.root()) {
+        tracing::debug!(
+            "not recording the workspace input fingerprint: the lock file contains source packages"
+        );
+        return;
+    }
+
+    match try_record(workspace).await {
+        Ok(path) => {
+            tracing::debug!(
+                "recorded the workspace input fingerprint at `{}`",
+                path.display()
+            );
+        }
+        Err(err) => {
+            tracing::debug!("failed to record the workspace input fingerprint: {err}");
+        }
+    }
+}
+
+/// Computes and atomically persists the fingerprint, returning the marker
+/// path on success.
+async fn try_record(workspace: &Workspace) -> Result<PathBuf, FreshnessError> {
+    let inputs = gather_inputs(workspace).await?;
+    let fingerprint = WorkspaceFingerprint::compute(&inputs);
+    let bytes = fingerprint
+        .to_json_bytes()
+        .map_err(|source| FreshnessError::Serialize {
+            what: "the workspace input fingerprint",
+            source,
+        })?;
+    let path = workspace_fingerprint_path(workspace);
+    store::write_marker_bytes(&path, &bytes).await?;
+    Ok(path)
+}
+
+/// Returns true when any environment in the lock file contains source
+/// packages on any platform: conda source packages, or pypi packages whose
+/// location is a path resolving to a directory (the kind of dependency that
+/// changes without the lock file changing).
+///
+/// A sibling of this rule lives inline in `UpdateContextInner::cached_prefix`
+/// (`lock_file/update.rs`), scoped to the current platform and manifest
+/// declarations. This scan is deliberately broader (all environments, all
+/// platforms, locked locations) because it gates skipping the entire
+/// up-to-date walk; when changing one, review the other.
+fn lock_file_contains_source_packages(lock_file: &LockFile, workspace_root: &Path) -> bool {
+    lock_file.environments().any(|(_, environment)| {
+        environment.packages_by_platform().any(|(_, mut packages)| {
+            packages.any(|package| match package {
+                LockedPackage::Conda(conda) => conda.as_source().is_some(),
+                LockedPackage::Pypi(pypi) => match &**pypi.location() {
+                    UrlOrPath::Path(path) => {
+                        let absolute_path = if path.is_absolute() {
+                            PathBuf::from(path.as_str())
+                        } else {
+                            workspace_root.join(Path::new(path.as_str()))
+                        };
+                        absolute_path.is_dir()
+                    }
+                    UrlOrPath::Url(_) => false,
+                },
+            })
+        })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use rattler_conda_types::Platform;
+    use rattler_lock::{PlatformData, PypiPackageData, PypiSourceData, SourceData, Verbatim};
+
+    use super::*;
+
+    const MANIFEST: &str = "[workspace]\nname = \"fresh\"\nchannels = []\nplatforms = []\n";
+
+    /// Builds a workspace in a temp dir with the freshness flag set in the
+    /// project-local config.
+    fn workspace_with_flag(temp: &Path, enabled: bool) -> Workspace {
+        let manifest_path = temp.join("pixi.toml");
+        fs_err::write(&manifest_path, MANIFEST).unwrap();
+        let pixi_dir = temp.join(".pixi");
+        fs_err::create_dir_all(&pixi_dir).unwrap();
+        fs_err::write(
+            pixi_dir.join("config.toml"),
+            format!("[experimental]\nuse-workspace-freshness-cache = {enabled}\n"),
+        )
+        .unwrap();
+        Workspace::from_str(&manifest_path, MANIFEST).unwrap()
+    }
+
+    /// Builds a lock file whose default environment contains a single pypi
+    /// package located at `location`.
+    fn lock_with_pypi_path_package(location: &str) -> LockFile {
+        let platform = Platform::Linux64;
+        let package = PypiPackageData::Source(Box::new(PypiSourceData {
+            name: "mypkg".parse().unwrap(),
+            location: Verbatim::new(UrlOrPath::Path(location.into())),
+            requires_dist: vec![],
+            requires_python: None,
+            source_data: SourceData::default(),
+        }));
+        LockFile::builder()
+            .with_platforms(vec![PlatformData {
+                name: (&platform).into(),
+                subdir: platform,
+                virtual_packages: vec![],
+            }])
+            .unwrap()
+            .with_pypi_package("default", "linux-64", package)
+            .unwrap()
+            .finish()
+    }
+
+    #[test]
+    fn config_digest_is_stable_across_map_iteration_orders() {
+        // `Config` contains `HashMap` fields (mirrors, s3-options) whose
+        // iteration order is randomized per instance. The serialized config
+        // must be canonicalized before hashing, otherwise every process would
+        // compute a different `resolved-config` digest and the fast path
+        // would silently never engage for users of those settings.
+        let mirror_urls: Vec<(url::Url, Vec<url::Url>)> = (0..12)
+            .map(|index| {
+                (
+                    url::Url::parse(&format!("https://channel-{index}.example.com")).unwrap(),
+                    vec![url::Url::parse(&format!("https://mirror-{index}.example.com")).unwrap()],
+                )
+            })
+            .collect();
+
+        // Two configs with identical content, built with opposite insertion
+        // orders (fresh `HashMap` instances hash-seed differently).
+        let forward = pixi_config::Config {
+            mirrors: mirror_urls.iter().cloned().collect(),
+            ..pixi_config::Config::default()
+        };
+        let backward = pixi_config::Config {
+            mirrors: mirror_urls.iter().rev().cloned().collect(),
+            ..pixi_config::Config::default()
+        };
+
+        assert_eq!(
+            canonical_config_json(&forward).unwrap(),
+            canonical_config_json(&backward).unwrap(),
+            "equal configs must serialize to identical canonical bytes"
+        );
+    }
+
+    #[tokio::test]
+    async fn record_then_check_roundtrip() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = workspace_with_flag(temp.path(), true);
+        assert!(
+            workspace
+                .config()
+                .experimental_workspace_freshness_cache_usage()
+        );
+        let marker = workspace_fingerprint_path(&workspace);
+
+        // No marker yet.
+        assert_eq!(
+            check_workspace_freshness(&workspace).await,
+            FreshnessCheck::Absent
+        );
+
+        // Record against an empty lock file (no source packages).
+        record_workspace_freshness(
+            &workspace,
+            &LockFile::default(),
+            LockFileUsage::Update,
+            false,
+        )
+        .await;
+        assert!(marker.is_file(), "marker should exist at {marker:?}");
+
+        // Unchanged inputs validate as fresh.
+        assert_eq!(
+            check_workspace_freshness(&workspace).await,
+            FreshnessCheck::Fresh
+        );
+
+        // Changing the manifest on disk invalidates the fingerprint.
+        fs_err::write(
+            temp.path().join("pixi.toml"),
+            MANIFEST.replace("fresh", "renamed"),
+        )
+        .unwrap();
+        assert_eq!(
+            check_workspace_freshness(&workspace).await,
+            FreshnessCheck::Stale(StaleReason::ManifestChanged)
+        );
+
+        // A corrupt marker degrades to absent, not an error.
+        fs_err::write(&marker, "definitely-not-json").unwrap();
+        assert_eq!(
+            check_workspace_freshness(&workspace).await,
+            FreshnessCheck::Absent
+        );
+    }
+
+    #[tokio::test]
+    async fn lock_file_appearing_invalidates_fingerprint() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = workspace_with_flag(temp.path(), true);
+
+        // Recorded with no lock file on disk (absent sentinel).
+        record_workspace_freshness(
+            &workspace,
+            &LockFile::default(),
+            LockFileUsage::Update,
+            false,
+        )
+        .await;
+        assert_eq!(
+            check_workspace_freshness(&workspace).await,
+            FreshnessCheck::Fresh
+        );
+
+        // A lock file appearing on disk is a lock content change.
+        fs_err::write(workspace.lock_file_path(), "version: 6\n").unwrap();
+        assert_eq!(
+            check_workspace_freshness(&workspace).await,
+            FreshnessCheck::Stale(StaleReason::LockFileChanged)
+        );
+    }
+
+    #[tokio::test]
+    async fn record_skips_when_flag_off() {
+        let temp = tempfile::tempdir().unwrap();
+        // Explicitly `false` so a developer's global config cannot leak in.
+        let workspace = workspace_with_flag(temp.path(), false);
+
+        record_workspace_freshness(
+            &workspace,
+            &LockFile::default(),
+            LockFileUsage::Update,
+            false,
+        )
+        .await;
+        assert!(!workspace_fingerprint_path(&workspace).exists());
+    }
+
+    #[tokio::test]
+    async fn record_skips_with_pypi_directory_source_package() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = workspace_with_flag(temp.path(), true);
+
+        // A pypi path dependency pointing at an existing directory blocks
+        // recording (v1 has no probes for source file sets).
+        fs_err::create_dir_all(temp.path().join("mypkg")).unwrap();
+        let lock = lock_with_pypi_path_package("./mypkg");
+        assert!(lock_file_contains_source_packages(&lock, workspace.root()));
+        record_workspace_freshness(&workspace, &lock, LockFileUsage::Update, false).await;
+        assert!(!workspace_fingerprint_path(&workspace).exists());
+
+        // A path location that is not a directory (e.g. an sdist archive)
+        // does not block recording.
+        let lock = lock_with_pypi_path_package("./mypkg-1.0.tar.gz");
+        assert!(!lock_file_contains_source_packages(&lock, workspace.root()));
+        record_workspace_freshness(&workspace, &lock, LockFileUsage::Update, false).await;
+        assert!(workspace_fingerprint_path(&workspace).is_file());
+    }
+}

--- a/crates/pixi_core/src/lock_file/freshness/probe.rs
+++ b/crates/pixi_core/src/lock_file/freshness/probe.rs
@@ -1,0 +1,773 @@
+//! The pure probe model behind the workspace input fingerprint.
+//!
+//! Everything in this module is a pure function over bytes/values: probe
+//! computation and validation take a [`FingerprintInputs`] snapshot instead of
+//! touching a `Workspace` or the filesystem. The glue that adapts a
+//! `Workspace` to a [`FingerprintInputs`] lives in the parent module. This
+//! separation is what makes the model unit-testable without constructing a
+//! workspace or mutating process-global state (like environment variables).
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use xxhash_rust::xxh3::xxh3_64;
+
+/// The current schema version of the serialized [`WorkspaceFingerprint`].
+///
+/// Bump this when the meaning of an existing probe changes. A marker recorded
+/// with a different schema version is treated as stale, never as an error.
+pub const FINGERPRINT_SCHEMA_VERSION: u32 = 1;
+
+/// Environment variables whose name starts with this prefix override virtual
+/// package detection and therefore affect resolution.
+pub const CONDA_OVERRIDE_PREFIX: &str = "CONDA_OVERRIDE_";
+
+/// Environment variables whose name starts with this prefix override pixi's
+/// own platform/virtual-package handling (`PIXI_OVERRIDE_PLATFORM` today) and
+/// therefore affect resolution.
+pub const PIXI_OVERRIDE_PREFIX: &str = "PIXI_OVERRIDE_";
+
+/// Digest value recorded for the lock-file probe when no lock file exists on
+/// disk. Distinct from every real digest (those are 16 hex characters).
+const LOCK_FILE_ABSENT_DIGEST: &str = "absent";
+
+/// Probe kind names, used for the `kind` tag on disk and in stale reasons.
+///
+/// These must mirror the serde kebab-case tags of [`InputProbe`]; the
+/// `computed_probes_cover_exactly_the_required_kinds` test pins the sync.
+mod kind {
+    pub const MANIFEST_FILE_CONTENT: &str = "manifest-file-content";
+    pub const RESOLVED_CONFIG: &str = "resolved-config";
+    pub const LOCK_FILE_CONTENT: &str = "lock-file-content";
+    pub const ENV_VARS: &str = "env-vars";
+    pub const PIXI_VERSION: &str = "pixi-version";
+}
+
+/// Every probe kind a v1 fingerprint must record for validation to be able
+/// to return fresh.
+///
+/// This is the single authoritative list: [`WorkspaceFingerprint::validate`]
+/// checks marker completeness against it, and the
+/// `computed_probes_cover_exactly_the_required_kinds` test asserts that
+/// [`WorkspaceFingerprint::compute`] emits exactly these kinds — so adding a
+/// probe to `compute` without extending this list (or vice versa) fails a
+/// test instead of silently letting markers that lack the new probe validate
+/// as fresh.
+const REQUIRED_PROBE_KINDS: [&str; 5] = [
+    kind::MANIFEST_FILE_CONTENT,
+    kind::RESOLVED_CONFIG,
+    kind::LOCK_FILE_CONTENT,
+    kind::ENV_VARS,
+    kind::PIXI_VERSION,
+];
+
+/// A single independently re-checkable statement about one resolution input.
+///
+/// The enum is internally tagged (`kind`) with a catch-all [`Self::Unknown`]
+/// variant so that markers written by a newer pixi deserialize without error;
+/// validation then reports them as stale instead of failing.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum InputProbe {
+    /// xxh3 digest of the raw bytes of the workspace manifest file
+    /// (`pixi.toml` / `pyproject.toml` / `mojoproject.toml`).
+    ManifestFileContent {
+        /// The absolute path of the manifest the digest was computed from.
+        path: String,
+        /// Hex-encoded xxh3 of the manifest file bytes.
+        digest: String,
+    },
+    /// xxh3 digest of the JSON serialization of the merged, resolved
+    /// configuration. Field-order drift between pixi versions is pinned by the
+    /// [`InputProbe::PixiVersion`] probe.
+    ResolvedConfig {
+        /// Hex-encoded xxh3 of the serialized configuration.
+        digest: String,
+    },
+    /// xxh3 digest of the raw on-disk bytes of `pixi.lock`, or a sentinel when
+    /// the file does not exist.
+    LockFileContent {
+        /// Hex-encoded xxh3 of the lock file bytes, or `"absent"`.
+        digest: String,
+    },
+    /// The resolution-affecting override environment variables and their
+    /// values at record time. `None` means the variable was unset.
+    EnvVars {
+        /// Variable name to value (or `None` when unset at record time).
+        vars: BTreeMap<String, Option<String>>,
+    },
+    /// The pixi version that recorded the fingerprint.
+    PixiVersion {
+        /// The value of `consts::PIXI_VERSION` at record time.
+        version: String,
+    },
+    /// A probe kind this version of pixi does not know about. Deserialization
+    /// never fails on it; validation reports it as stale.
+    #[serde(other)]
+    Unknown,
+}
+
+/// A snapshot of the current values of all L0 inputs covered by v1 probes.
+///
+/// Pure data: the glue layer fills this from a `Workspace`, unit tests fill it
+/// directly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FingerprintInputs {
+    /// Absolute path of the workspace manifest file.
+    pub manifest_path: String,
+    /// Raw bytes of the workspace manifest file.
+    pub manifest_bytes: Vec<u8>,
+    /// JSON serialization of the merged, resolved configuration.
+    pub config_json: Vec<u8>,
+    /// Raw bytes of the lock file, or `None` when no lock file exists.
+    pub lock_file_bytes: Option<Vec<u8>>,
+    /// The override environment variables, as gathered by
+    /// [`collect_override_env_vars`].
+    pub override_env_vars: BTreeMap<String, Option<String>>,
+    /// The current pixi version.
+    pub pixi_version: String,
+}
+
+/// The reason a recorded fingerprint no longer matches the current inputs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StaleReason {
+    /// The marker was written with a different schema version.
+    SchemaVersion {
+        /// The schema version found in the marker.
+        recorded: u32,
+        /// The schema version this pixi supports.
+        supported: u32,
+    },
+    /// The marker contains a probe kind this pixi does not understand.
+    UnknownProbe,
+    /// The marker lacks a probe kind that v1 requires.
+    MissingProbe {
+        /// The `kind` tag of the missing probe.
+        kind: &'static str,
+    },
+    /// The manifest file moved or its content changed.
+    ManifestChanged,
+    /// The merged, resolved configuration changed.
+    ConfigChanged,
+    /// The lock file bytes changed (including appearing or disappearing).
+    LockFileChanged,
+    /// An override environment variable was set, unset, or changed.
+    EnvVarChanged {
+        /// The name of the first differing variable.
+        name: String,
+    },
+    /// The fingerprint was recorded by a different pixi version.
+    PixiVersionChanged {
+        /// The version that recorded the marker.
+        recorded: String,
+        /// The currently running version.
+        current: String,
+    },
+    /// A current input could not be gathered (e.g. the manifest disappeared).
+    InputUnavailable {
+        /// Human-readable description of what failed.
+        reason: String,
+    },
+}
+
+impl std::fmt::Display for StaleReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StaleReason::SchemaVersion {
+                recorded,
+                supported,
+            } => write!(
+                f,
+                "the marker uses schema version {recorded}, this version of pixi supports {supported}"
+            ),
+            StaleReason::UnknownProbe => {
+                write!(
+                    f,
+                    "the marker contains a probe kind unknown to this version of pixi"
+                )
+            }
+            StaleReason::MissingProbe { kind } => {
+                write!(f, "the marker lacks the required `{kind}` probe")
+            }
+            StaleReason::ManifestChanged => write!(f, "the workspace manifest changed"),
+            StaleReason::ConfigChanged => write!(f, "the resolved configuration changed"),
+            StaleReason::LockFileChanged => write!(f, "the lock file changed"),
+            StaleReason::EnvVarChanged { name } => {
+                write!(f, "the environment variable `{name}` changed")
+            }
+            StaleReason::PixiVersionChanged { recorded, current } => write!(
+                f,
+                "the marker was recorded by pixi {recorded}, currently running {current}"
+            ),
+            StaleReason::InputUnavailable { reason } => {
+                write!(f, "a required input could not be read: {reason}")
+            }
+        }
+    }
+}
+
+/// The outcome of validating a parsed fingerprint against current inputs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProbeValidation {
+    /// Every probe matched: the inputs are unchanged.
+    Fresh,
+    /// At least one probe did not match.
+    Stale(StaleReason),
+}
+
+/// The outcome of evaluating an on-disk marker, including the cases where no
+/// usable marker exists.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FreshnessCheck {
+    /// A valid marker exists and every probe matched.
+    Fresh,
+    /// A valid marker exists but at least one probe did not match.
+    Stale(StaleReason),
+    /// No marker exists, or it could not be read or parsed.
+    Absent,
+}
+
+/// A recorded, re-checkable trace of the workspace's resolution inputs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspaceFingerprint {
+    /// Schema version of this marker; see [`FINGERPRINT_SCHEMA_VERSION`].
+    pub schema_version: u32,
+    /// The recorded probes.
+    pub probes: Vec<InputProbe>,
+}
+
+/// Returns the hex-encoded xxh3 digest of `bytes`.
+pub(crate) fn digest_bytes(bytes: &[u8]) -> String {
+    format!("{:016x}", xxh3_64(bytes))
+}
+
+/// Returns the digest recorded for the lock-file probe: the digest of the
+/// bytes, or a distinct sentinel when the file is absent.
+fn lock_file_digest(bytes: Option<&[u8]>) -> String {
+    match bytes {
+        Some(bytes) => digest_bytes(bytes),
+        None => LOCK_FILE_ABSENT_DIGEST.to_string(),
+    }
+}
+
+/// Collects the resolution-affecting override environment variables from an
+/// arbitrary variable listing.
+///
+/// Included are every variable whose name starts with
+/// [`CONDA_OVERRIDE_PREFIX`] or [`PIXI_OVERRIDE_PREFIX`]; both are prefix
+/// matches so that overrides added later (in rattler or in
+/// `Workspace::host_platform` and friends, see
+/// `crate::workspace::PlatformOverrides`) are captured without this list
+/// needing to know about them — over-invalidation is safe,
+/// under-invalidation is not. `PIXI_OVERRIDE_PLATFORM` is additionally always
+/// present in the result (with `None` when unset) so set/unset transitions
+/// are caught. Pure function: pass `std::env::vars_os()` (lossily converted)
+/// in production, a literal iterator in tests.
+pub fn collect_override_env_vars(
+    vars: impl IntoIterator<Item = (String, String)>,
+) -> BTreeMap<String, Option<String>> {
+    let mut collected: BTreeMap<String, Option<String>> = BTreeMap::new();
+    // Always present so a set/unset transition changes the map.
+    collected.insert(
+        pixi_consts::consts::PIXI_OVERRIDE_PLATFORM.to_string(),
+        None,
+    );
+    for (name, value) in vars {
+        if name.starts_with(CONDA_OVERRIDE_PREFIX) || name.starts_with(PIXI_OVERRIDE_PREFIX) {
+            collected.insert(name, Some(value));
+        }
+    }
+    collected
+}
+
+/// Returns the first variable name at which the two maps differ, if any.
+fn first_env_var_difference(
+    recorded: &BTreeMap<String, Option<String>>,
+    current: &BTreeMap<String, Option<String>>,
+) -> Option<String> {
+    recorded
+        .iter()
+        .find(|(name, value)| current.get(*name) != Some(value))
+        .map(|(name, _)| name.clone())
+        .or_else(|| {
+            current
+                .keys()
+                .find(|name| !recorded.contains_key(*name))
+                .cloned()
+        })
+}
+
+impl WorkspaceFingerprint {
+    /// Computes the fingerprint of the given input snapshot.
+    pub fn compute(inputs: &FingerprintInputs) -> Self {
+        Self {
+            schema_version: FINGERPRINT_SCHEMA_VERSION,
+            probes: vec![
+                InputProbe::ManifestFileContent {
+                    path: inputs.manifest_path.clone(),
+                    digest: digest_bytes(&inputs.manifest_bytes),
+                },
+                InputProbe::ResolvedConfig {
+                    digest: digest_bytes(&inputs.config_json),
+                },
+                InputProbe::LockFileContent {
+                    digest: lock_file_digest(inputs.lock_file_bytes.as_deref()),
+                },
+                InputProbe::EnvVars {
+                    vars: inputs.override_env_vars.clone(),
+                },
+                InputProbe::PixiVersion {
+                    version: inputs.pixi_version.clone(),
+                },
+            ],
+        }
+    }
+
+    /// Validates this fingerprint against the given input snapshot.
+    ///
+    /// Returns [`ProbeValidation::Fresh`] only when the schema version
+    /// matches, every recorded probe re-validates, no probe is of an unknown
+    /// kind, and every probe kind required by v1 is present.
+    pub fn validate(&self, inputs: &FingerprintInputs) -> ProbeValidation {
+        if self.schema_version != FINGERPRINT_SCHEMA_VERSION {
+            return ProbeValidation::Stale(StaleReason::SchemaVersion {
+                recorded: self.schema_version,
+                supported: FINGERPRINT_SCHEMA_VERSION,
+            });
+        }
+
+        let mut seen_kinds = Vec::with_capacity(self.probes.len());
+        for probe in &self.probes {
+            match probe {
+                InputProbe::ManifestFileContent { path, digest } => {
+                    seen_kinds.push(kind::MANIFEST_FILE_CONTENT);
+                    if *path != inputs.manifest_path
+                        || *digest != digest_bytes(&inputs.manifest_bytes)
+                    {
+                        return ProbeValidation::Stale(StaleReason::ManifestChanged);
+                    }
+                }
+                InputProbe::ResolvedConfig { digest } => {
+                    seen_kinds.push(kind::RESOLVED_CONFIG);
+                    if *digest != digest_bytes(&inputs.config_json) {
+                        return ProbeValidation::Stale(StaleReason::ConfigChanged);
+                    }
+                }
+                InputProbe::LockFileContent { digest } => {
+                    seen_kinds.push(kind::LOCK_FILE_CONTENT);
+                    if *digest != lock_file_digest(inputs.lock_file_bytes.as_deref()) {
+                        return ProbeValidation::Stale(StaleReason::LockFileChanged);
+                    }
+                }
+                InputProbe::EnvVars { vars } => {
+                    seen_kinds.push(kind::ENV_VARS);
+                    if let Some(name) = first_env_var_difference(vars, &inputs.override_env_vars) {
+                        return ProbeValidation::Stale(StaleReason::EnvVarChanged { name });
+                    }
+                }
+                InputProbe::PixiVersion { version } => {
+                    seen_kinds.push(kind::PIXI_VERSION);
+                    if *version != inputs.pixi_version {
+                        return ProbeValidation::Stale(StaleReason::PixiVersionChanged {
+                            recorded: version.clone(),
+                            current: inputs.pixi_version.clone(),
+                        });
+                    }
+                }
+                InputProbe::Unknown => {
+                    return ProbeValidation::Stale(StaleReason::UnknownProbe);
+                }
+            }
+        }
+
+        // Every probe kind v1 relies on must be present: a marker that lost a
+        // probe proves nothing about that input.
+        for required in REQUIRED_PROBE_KINDS {
+            if !seen_kinds.contains(&required) {
+                return ProbeValidation::Stale(StaleReason::MissingProbe { kind: required });
+            }
+        }
+
+        ProbeValidation::Fresh
+    }
+
+    /// Serializes the fingerprint to pretty-printed JSON bytes.
+    pub fn to_json_bytes(&self) -> Result<Vec<u8>, serde_json::Error> {
+        serde_json::to_vec_pretty(self)
+    }
+}
+
+/// Evaluates an on-disk marker (if any) against the current inputs.
+///
+/// * `None` or unparseable bytes ⇒ [`FreshnessCheck::Absent`],
+/// * a parseable marker ⇒ the result of [`WorkspaceFingerprint::validate`].
+///
+/// Every failure mode degrades to a miss (slow but correct), never an error.
+pub fn evaluate_marker(marker_bytes: Option<&[u8]>, inputs: &FingerprintInputs) -> FreshnessCheck {
+    let Some(bytes) = marker_bytes else {
+        return FreshnessCheck::Absent;
+    };
+    match serde_json::from_slice::<WorkspaceFingerprint>(bytes) {
+        Ok(fingerprint) => match fingerprint.validate(inputs) {
+            ProbeValidation::Fresh => FreshnessCheck::Fresh,
+            ProbeValidation::Stale(reason) => FreshnessCheck::Stale(reason),
+        },
+        // A corrupt marker is not a marker.
+        Err(_) => FreshnessCheck::Absent,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A fully populated input snapshot used as the "recorded" state.
+    fn sample_inputs() -> FingerprintInputs {
+        FingerprintInputs {
+            manifest_path: "/workspace/pixi.toml".to_string(),
+            manifest_bytes: b"[workspace]\nname = \"test\"\n".to_vec(),
+            config_json: br#"{"default-channels":["conda-forge"]}"#.to_vec(),
+            lock_file_bytes: Some(b"version: 6\nenvironments: {}\npackages: []\n".to_vec()),
+            override_env_vars: collect_override_env_vars([
+                ("CONDA_OVERRIDE_CUDA".to_string(), "12.0".to_string()),
+                ("HOME".to_string(), "/home/user".to_string()),
+            ]),
+            pixi_version: "1.2.3".to_string(),
+        }
+    }
+
+    #[test]
+    fn collect_override_env_vars_filters_and_pins_platform_override() {
+        let vars = collect_override_env_vars([
+            ("CONDA_OVERRIDE_CUDA".to_string(), "12.0".to_string()),
+            ("CONDA_OVERRIDE_GLIBC".to_string(), "2.28".to_string()),
+            ("PATH".to_string(), "/usr/bin".to_string()),
+            ("CONDA_PREFIX".to_string(), "/opt/conda".to_string()),
+        ]);
+
+        // Both CONDA_OVERRIDE_* vars are captured with their values.
+        assert_eq!(
+            vars.get("CONDA_OVERRIDE_CUDA"),
+            Some(&Some("12.0".to_string()))
+        );
+        assert_eq!(
+            vars.get("CONDA_OVERRIDE_GLIBC"),
+            Some(&Some("2.28".to_string()))
+        );
+        // PIXI_OVERRIDE_PLATFORM is always present, `None` when unset.
+        assert_eq!(vars.get("PIXI_OVERRIDE_PLATFORM"), Some(&None));
+        // Unrelated variables are not captured.
+        assert_eq!(vars.len(), 3);
+
+        // When PIXI_OVERRIDE_PLATFORM is set, its value is captured.
+        let vars = collect_override_env_vars([(
+            "PIXI_OVERRIDE_PLATFORM".to_string(),
+            "linux-64".to_string(),
+        )]);
+        assert_eq!(
+            vars.get("PIXI_OVERRIDE_PLATFORM"),
+            Some(&Some("linux-64".to_string()))
+        );
+        assert_eq!(vars.len(), 1);
+
+        // Any future pixi-side override variable is captured by prefix, so
+        // the probe cannot silently lag behind newly honored overrides
+        // (over-invalidation is safe, under-invalidation is not).
+        let vars = collect_override_env_vars([(
+            "PIXI_OVERRIDE_VIRTUAL_PACKAGES".to_string(),
+            "cuda=12".to_string(),
+        )]);
+        assert_eq!(
+            vars.get("PIXI_OVERRIDE_VIRTUAL_PACKAGES"),
+            Some(&Some("cuda=12".to_string()))
+        );
+    }
+
+    #[test]
+    fn computed_probes_cover_exactly_the_required_kinds() {
+        // Pins the sync between `compute` and `REQUIRED_PROBE_KINDS`: adding
+        // a probe to one without the other must fail here, otherwise markers
+        // lacking the new probe would keep validating as fresh.
+        let fingerprint = WorkspaceFingerprint::compute(&sample_inputs());
+        let computed_kinds: Vec<String> = fingerprint
+            .probes
+            .iter()
+            .map(|probe| {
+                serde_json::to_value(probe).unwrap()["kind"]
+                    .as_str()
+                    .unwrap()
+                    .to_string()
+            })
+            .collect();
+        assert_eq!(computed_kinds, REQUIRED_PROBE_KINDS);
+    }
+
+    #[test]
+    fn serde_roundtrip_preserves_fingerprint() {
+        let inputs = sample_inputs();
+        let fingerprint = WorkspaceFingerprint::compute(&inputs);
+        assert_eq!(fingerprint.schema_version, FINGERPRINT_SCHEMA_VERSION);
+
+        let bytes = fingerprint.to_json_bytes().unwrap();
+        let parsed: WorkspaceFingerprint = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(parsed, fingerprint);
+
+        // A roundtripped fingerprint still validates as fresh.
+        assert_eq!(parsed.validate(&inputs), ProbeValidation::Fresh);
+    }
+
+    #[test]
+    fn all_probes_matching_is_fresh() {
+        let inputs = sample_inputs();
+        let fingerprint = WorkspaceFingerprint::compute(&inputs);
+        assert_eq!(fingerprint.validate(&inputs), ProbeValidation::Fresh);
+        assert_eq!(
+            evaluate_marker(Some(&fingerprint.to_json_bytes().unwrap()), &inputs),
+            FreshnessCheck::Fresh
+        );
+    }
+
+    #[test]
+    fn manifest_content_change_is_stale() {
+        let inputs = sample_inputs();
+        let fingerprint = WorkspaceFingerprint::compute(&inputs);
+
+        let mut changed = inputs.clone();
+        changed.manifest_bytes = b"[workspace]\nname = \"changed\"\n".to_vec();
+        assert_eq!(
+            fingerprint.validate(&changed),
+            ProbeValidation::Stale(StaleReason::ManifestChanged)
+        );
+    }
+
+    #[test]
+    fn manifest_path_change_is_stale() {
+        let inputs = sample_inputs();
+        let fingerprint = WorkspaceFingerprint::compute(&inputs);
+
+        let mut changed = inputs.clone();
+        changed.manifest_path = "/workspace/pyproject.toml".to_string();
+        assert_eq!(
+            fingerprint.validate(&changed),
+            ProbeValidation::Stale(StaleReason::ManifestChanged)
+        );
+    }
+
+    #[test]
+    fn config_change_is_stale() {
+        let inputs = sample_inputs();
+        let fingerprint = WorkspaceFingerprint::compute(&inputs);
+
+        let mut changed = inputs.clone();
+        changed.config_json = br#"{"default-channels":["bioconda"]}"#.to_vec();
+        assert_eq!(
+            fingerprint.validate(&changed),
+            ProbeValidation::Stale(StaleReason::ConfigChanged)
+        );
+    }
+
+    #[test]
+    fn lock_file_change_is_stale() {
+        let inputs = sample_inputs();
+        let fingerprint = WorkspaceFingerprint::compute(&inputs);
+
+        // Changed bytes.
+        let mut changed = inputs.clone();
+        changed.lock_file_bytes = Some(b"version: 6\nsomething: else\n".to_vec());
+        assert_eq!(
+            fingerprint.validate(&changed),
+            ProbeValidation::Stale(StaleReason::LockFileChanged)
+        );
+
+        // Present -> absent.
+        let mut removed = inputs.clone();
+        removed.lock_file_bytes = None;
+        assert_eq!(
+            fingerprint.validate(&removed),
+            ProbeValidation::Stale(StaleReason::LockFileChanged)
+        );
+
+        // Absent at record time -> present now.
+        let mut absent_inputs = inputs.clone();
+        absent_inputs.lock_file_bytes = None;
+        let absent_fingerprint = WorkspaceFingerprint::compute(&absent_inputs);
+        assert_eq!(
+            absent_fingerprint.validate(&absent_inputs),
+            ProbeValidation::Fresh
+        );
+        assert_eq!(
+            absent_fingerprint.validate(&inputs),
+            ProbeValidation::Stale(StaleReason::LockFileChanged)
+        );
+    }
+
+    #[test]
+    fn env_var_changes_are_stale() {
+        let inputs = sample_inputs();
+        let fingerprint = WorkspaceFingerprint::compute(&inputs);
+
+        // Changing the value of a recorded variable.
+        let mut changed = inputs.clone();
+        changed.override_env_vars =
+            collect_override_env_vars([("CONDA_OVERRIDE_CUDA".to_string(), "11.8".to_string())]);
+        assert_eq!(
+            fingerprint.validate(&changed),
+            ProbeValidation::Stale(StaleReason::EnvVarChanged {
+                name: "CONDA_OVERRIDE_CUDA".to_string()
+            })
+        );
+
+        // Unsetting a recorded variable.
+        let mut unset = inputs.clone();
+        unset.override_env_vars = collect_override_env_vars(std::iter::empty());
+        assert_eq!(
+            fingerprint.validate(&unset),
+            ProbeValidation::Stale(StaleReason::EnvVarChanged {
+                name: "CONDA_OVERRIDE_CUDA".to_string()
+            })
+        );
+
+        // Setting a new override variable that was unset at record time.
+        let mut added = inputs.clone();
+        added.override_env_vars = collect_override_env_vars([
+            ("CONDA_OVERRIDE_CUDA".to_string(), "12.0".to_string()),
+            ("CONDA_OVERRIDE_OSX".to_string(), "14.0".to_string()),
+        ]);
+        assert_eq!(
+            fingerprint.validate(&added),
+            ProbeValidation::Stale(StaleReason::EnvVarChanged {
+                name: "CONDA_OVERRIDE_OSX".to_string()
+            })
+        );
+
+        // Setting PIXI_OVERRIDE_PLATFORM (recorded as unset).
+        let mut platform_set = inputs.clone();
+        platform_set.override_env_vars = collect_override_env_vars([
+            ("CONDA_OVERRIDE_CUDA".to_string(), "12.0".to_string()),
+            (
+                "PIXI_OVERRIDE_PLATFORM".to_string(),
+                "osx-arm64".to_string(),
+            ),
+        ]);
+        assert_eq!(
+            fingerprint.validate(&platform_set),
+            ProbeValidation::Stale(StaleReason::EnvVarChanged {
+                name: "PIXI_OVERRIDE_PLATFORM".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn pixi_version_change_is_stale() {
+        let inputs = sample_inputs();
+        let fingerprint = WorkspaceFingerprint::compute(&inputs);
+
+        let mut changed = inputs.clone();
+        changed.pixi_version = "9.9.9".to_string();
+        assert_eq!(
+            fingerprint.validate(&changed),
+            ProbeValidation::Stale(StaleReason::PixiVersionChanged {
+                recorded: "1.2.3".to_string(),
+                current: "9.9.9".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn unknown_probe_kind_deserializes_and_is_stale() {
+        let inputs = sample_inputs();
+        let fingerprint = WorkspaceFingerprint::compute(&inputs);
+
+        // Simulate a marker written by a future pixi that records an extra
+        // probe kind with fields we know nothing about.
+        let mut value: serde_json::Value =
+            serde_json::from_slice(&fingerprint.to_json_bytes().unwrap()).unwrap();
+        value["probes"]
+            .as_array_mut()
+            .unwrap()
+            .push(serde_json::json!({
+                "kind": "file-set",
+                "root": "/workspace/src",
+                "globs": ["**/*.rs"],
+                "digest": "0011223344556677"
+            }));
+        let bytes = serde_json::to_vec(&value).unwrap();
+
+        // Deserialization must NOT fail...
+        let parsed: WorkspaceFingerprint = serde_json::from_slice(&bytes).unwrap();
+        assert!(parsed.probes.contains(&InputProbe::Unknown));
+
+        // ...and validation must report stale, not fresh and not absent.
+        assert_eq!(
+            evaluate_marker(Some(&bytes), &inputs),
+            FreshnessCheck::Stale(StaleReason::UnknownProbe)
+        );
+    }
+
+    #[test]
+    fn schema_version_mismatch_is_stale() {
+        let inputs = sample_inputs();
+        let mut fingerprint = WorkspaceFingerprint::compute(&inputs);
+        fingerprint.schema_version = FINGERPRINT_SCHEMA_VERSION + 1;
+        assert_eq!(
+            fingerprint.validate(&inputs),
+            ProbeValidation::Stale(StaleReason::SchemaVersion {
+                recorded: FINGERPRINT_SCHEMA_VERSION + 1,
+                supported: FINGERPRINT_SCHEMA_VERSION,
+            })
+        );
+    }
+
+    #[test]
+    fn missing_probe_is_stale() {
+        let inputs = sample_inputs();
+        let mut fingerprint = WorkspaceFingerprint::compute(&inputs);
+        fingerprint
+            .probes
+            .retain(|probe| !matches!(probe, InputProbe::PixiVersion { .. }));
+        assert_eq!(
+            fingerprint.validate(&inputs),
+            ProbeValidation::Stale(StaleReason::MissingProbe {
+                kind: "pixi-version"
+            })
+        );
+    }
+
+    #[test]
+    fn corrupt_or_missing_marker_is_absent() {
+        let inputs = sample_inputs();
+
+        // Missing marker.
+        assert_eq!(evaluate_marker(None, &inputs), FreshnessCheck::Absent);
+
+        // Not JSON at all.
+        assert_eq!(
+            evaluate_marker(Some(b"definitely not json"), &inputs),
+            FreshnessCheck::Absent
+        );
+
+        // Valid JSON with the wrong shape.
+        assert_eq!(
+            evaluate_marker(Some(br#"{"probes": "nope"}"#), &inputs),
+            FreshnessCheck::Absent
+        );
+
+        // Truncated marker.
+        let bytes = WorkspaceFingerprint::compute(&inputs)
+            .to_json_bytes()
+            .unwrap();
+        assert_eq!(
+            evaluate_marker(Some(&bytes[..bytes.len() / 2]), &inputs),
+            FreshnessCheck::Absent
+        );
+    }
+
+    #[test]
+    fn digests_are_hex_encoded_xxh3() {
+        // Pin the exact digest encoding: 16 lowercase hex chars of xxh3_64.
+        let digest = digest_bytes(b"hello");
+        assert_eq!(digest.len(), 16);
+        assert!(digest.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_eq!(digest, format!("{:016x}", xxh3_64(b"hello")));
+    }
+}

--- a/crates/pixi_core/src/lock_file/freshness/store.rs
+++ b/crates/pixi_core/src/lock_file/freshness/store.rs
@@ -1,0 +1,98 @@
+//! On-disk storage for the workspace input fingerprint marker.
+//!
+//! The marker lives at `<workspace>/.pixi/freshness/workspace.json`. Reads
+//! degrade to "no marker" on any failure; writes are atomic (temp file +
+//! rename) so a crashed pixi never leaves a truncated marker behind.
+
+use std::path::{Path, PathBuf};
+
+use super::FreshnessError;
+
+/// Name of the directory under `.pixi/` that holds freshness markers.
+pub const FRESHNESS_DIR: &str = "freshness";
+
+/// File name of the workspace-scoped input fingerprint marker.
+pub const WORKSPACE_FINGERPRINT_FILE: &str = "workspace.json";
+
+/// Returns the path of the workspace fingerprint marker inside the given
+/// `.pixi` directory.
+pub fn fingerprint_path(pixi_dir: &Path) -> PathBuf {
+    pixi_dir
+        .join(FRESHNESS_DIR)
+        .join(WORKSPACE_FINGERPRINT_FILE)
+}
+
+/// Reads the raw marker bytes, returning `None` when the file is missing or
+/// unreadable. Never fails: an unreadable marker is simply not a marker.
+pub async fn read_marker_bytes(path: &Path) -> Option<Vec<u8>> {
+    match fs_err::tokio::read(path).await {
+        Ok(bytes) => Some(bytes),
+        Err(err) => {
+            if err.kind() != std::io::ErrorKind::NotFound {
+                tracing::debug!(
+                    "failed to read the freshness marker at `{}`: {err}",
+                    path.display()
+                );
+            }
+            None
+        }
+    }
+}
+
+/// Atomically writes the marker bytes, creating parent directories as needed.
+pub async fn write_marker_bytes(path: &Path, bytes: &[u8]) -> Result<(), FreshnessError> {
+    if let Some(parent) = path.parent() {
+        fs_err::tokio::create_dir_all(parent)
+            .await
+            .map_err(|source| FreshnessError::WriteMarker {
+                path: path.to_path_buf(),
+                source,
+            })?;
+    }
+    pixi_utils::atomic_write::atomic_write(path, bytes)
+        .await
+        .map_err(|source| FreshnessError::WriteMarker {
+            path: path.to_path_buf(),
+            source,
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fingerprint_path_is_under_freshness_dir() {
+        let path = fingerprint_path(Path::new("/workspace/.pixi"));
+        assert_eq!(path, Path::new("/workspace/.pixi/freshness/workspace.json"));
+    }
+
+    #[tokio::test]
+    async fn write_then_read_roundtrips_and_creates_parents() {
+        let temp = tempfile::tempdir().unwrap();
+        // The `freshness/` directory does not exist yet.
+        let path = fingerprint_path(&temp.path().join(".pixi"));
+
+        write_marker_bytes(&path, b"{\"schema_version\":1}")
+            .await
+            .unwrap();
+        assert_eq!(
+            read_marker_bytes(&path).await.as_deref(),
+            Some(b"{\"schema_version\":1}".as_slice())
+        );
+
+        // Overwriting replaces the content.
+        write_marker_bytes(&path, b"{}").await.unwrap();
+        assert_eq!(
+            read_marker_bytes(&path).await.as_deref(),
+            Some(b"{}".as_slice())
+        );
+    }
+
+    #[tokio::test]
+    async fn read_missing_marker_is_none() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = fingerprint_path(&temp.path().join(".pixi"));
+        assert_eq!(read_marker_bytes(&path).await, None);
+    }
+}

--- a/crates/pixi_core/src/lock_file/mod.rs
+++ b/crates/pixi_core/src/lock_file/mod.rs
@@ -1,3 +1,4 @@
+pub mod freshness;
 mod install_subset;
 mod outdated;
 mod package_identifier;

--- a/crates/pixi_core/src/lock_file/outdated.rs
+++ b/crates/pixi_core/src/lock_file/outdated.rs
@@ -90,6 +90,14 @@ pub struct OutdatedEnvironments<'p> {
     /// This is shared across platforms since static metadata is platform-independent.
     pub static_metadata_cache: HashMap<PathBuf, pypi_metadata::LocalPackageMetadata>,
 
+    /// True when the satisfiability walk was interrupted by cancellation
+    /// (e.g. Ctrl-C shutting the command dispatcher down). Skipped targets
+    /// are silently treated as verified, so an empty [`Self::conda`]/
+    /// [`Self::pypi`] is *not* an up-to-date proof when this is set. Consumers
+    /// that persist "the lock file is up-to-date" conclusions (the workspace
+    /// freshness fingerprint) must not do so when this flag is true.
+    pub verification_cancelled: bool,
+
     /// Locked pypi records with metadata, resolved during the satisfiability
     /// check. Forwarded to the update path to avoid re-reading source trees.
     pub locked_pypi_records: HashMap<(Environment<'p>, PixiPlatformName), LockedPypiRecordsByName>,
@@ -132,6 +140,7 @@ impl<'p> OutdatedEnvironments<'p> {
                 mut outdated_conda,
                 mut outdated_pypi,
                 disregard_locked_content,
+                verification_cancelled,
             },
             uv_context,
             build_caches,
@@ -195,6 +204,7 @@ impl<'p> OutdatedEnvironments<'p> {
             build_caches,
             static_metadata_cache,
             locked_pypi_records,
+            verification_cancelled,
         }
     }
 
@@ -210,6 +220,9 @@ struct UnsatisfiableTargets<'p> {
     outdated_conda: HashMap<Environment<'p>, HashSet<PixiPlatformName>>,
     outdated_pypi: HashMap<Environment<'p>, HashSet<PixiPlatformName>>,
     disregard_locked_content: DisregardLockedContent<'p>,
+    /// True when at least one satisfiability task was cancelled, in which
+    /// case the outdated maps are incomplete rather than a proof.
+    verification_cancelled: bool,
 }
 
 /// Find all targets (combination of environment and platform) who's
@@ -407,6 +420,12 @@ async fn find_unsatisfiable_targets<'p>(
                 }
                 Err(CommandDispatcherError::Failed(_)) => unreachable!("platform task cannot fail"),
             }
+        }
+
+        // A cancelled walk silently skipped the remaining platforms: whatever
+        // was collected so far is incomplete, not a proof of freshness.
+        if platform_futures.is_cancelled() {
+            unsatisfiable_targets.verification_cancelled = true;
         }
     }
 

--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -61,7 +61,7 @@ use uv_normalize::ExtraName;
 
 use super::{
     CondaPrefixUpdater, InstallSubset, PixiRecordsByName, PypiRecordsByName,
-    UnresolvedPixiRecordsByName, outdated::OutdatedEnvironments, resolve_lock_platform,
+    UnresolvedPixiRecordsByName, freshness, outdated::OutdatedEnvironments, resolve_lock_platform,
     utils::IoConcurrencyLimit,
 };
 use crate::{
@@ -307,6 +307,41 @@ impl Workspace {
             return Ok((derived, false));
         }
 
+        // Experimental input-fingerprint fast path: when a previously
+        // recorded workspace fingerprint validates against the current
+        // inputs (manifest bytes, resolved config, lock bytes, override env
+        // vars, pixi version), the satisfiability result of the last
+        // successful run still holds, so building the resolver and walking
+        // `OutdatedEnvironments` can be skipped entirely. Any doubt (stale,
+        // absent, or corrupt marker) falls through to the normal path below.
+        let freshness_cache_enabled = self.config().experimental_workspace_freshness_cache_usage();
+        if freshness_cache_enabled
+            && !needs_format_upgrade
+            && matches!(options.lock_file_usage, LockFileUsage::Update)
+        {
+            match freshness::check_workspace_freshness(self).await {
+                freshness::FreshnessCheck::Fresh => {
+                    tracing::info!(
+                        "workspace inputs are unchanged since the last successful run; \
+                         skipping the lock file up-to-date check"
+                    );
+                    return Ok((derived, false));
+                }
+                freshness::FreshnessCheck::Stale(reason) => {
+                    tracing::debug!(
+                        "workspace input fingerprint is stale ({reason}); \
+                         running the full lock file up-to-date check"
+                    );
+                }
+                freshness::FreshnessCheck::Absent => {
+                    tracing::debug!(
+                        "no usable workspace input fingerprint; \
+                         running the full lock file up-to-date check"
+                    );
+                }
+            }
+        }
+
         // Check which environments are out of date.
         let resolver = derived.resolver()?;
         let mut outdated = OutdatedEnvironments::from_workspace_and_lock_file(
@@ -326,6 +361,24 @@ impl Workspace {
                 );
             } else {
                 tracing::info!("the lock file is up-to-date");
+            }
+
+            // The lock file was just proven consistent with its inputs:
+            // record the workspace input fingerprint so the next run can skip
+            // this check. `record_workspace_freshness` owns the eligibility
+            // predicate (flag, dry runs, old-format locks, source packages)
+            // and is non-fatal. Recording after `--frozen` is unreachable:
+            // that path returned above without proving anything. A cancelled
+            // walk (e.g. Ctrl-C mid-check) leaves `outdated` vacuously empty
+            // — that is not a proof, so nothing may be persisted from it.
+            if !outdated.verification_cancelled {
+                freshness::record_workspace_freshness(
+                    self,
+                    &derived.lock_file,
+                    options.lock_file_usage,
+                    needs_format_upgrade,
+                )
+                .await;
             }
 
             // If no-environment is outdated we can return early. Pass the
@@ -407,6 +460,21 @@ impl Workspace {
 
         if options.lock_file_usage != LockFileUsage::DryRun {
             lock_file_derived_data.write_to_disk()?;
+
+            // The solve succeeded and the lock file hit the disk in the
+            // latest format: record the workspace input fingerprint so the
+            // next run can skip the up-to-date check.
+            // `record_workspace_freshness` owns the eligibility predicate
+            // (flag, dry runs, source packages) and is non-fatal;
+            // `needs_format_upgrade` is `false` here because `write_to_disk`
+            // always writes the latest format.
+            freshness::record_workspace_freshness(
+                self,
+                &lock_file_derived_data.lock_file,
+                options.lock_file_usage,
+                false,
+            )
+            .await;
         }
 
         Ok((lock_file_derived_data, true))


### PR DESCRIPTION
### Description

Even when nothing changed at all, every pixi command re-proves that `pixi.lock` is consistent with its inputs from scratch: parse the lock file, build the resolver (cloning every conda record along the way), and walk satisfiability across every locked package for every environment and platform. For workspaces with large lock files this is most of what a no-op `pixi run` does after activation.

This adds a workspace input fingerprint: a record of everything the lock file's freshness actually depends on, namely the manifest bytes, the resolved config, the lock-file bytes themselves, the `CONDA_OVERRIDE_*`/`PIXI_OVERRIDE_*` variables, and the pixi version. It is recorded only after a run has proven the lock up to date (a passing satisfiability walk or a completed solve), and validated at the start of the next run; on a match, the resolver build and the satisfiability walk are skipped entirely. Any mismatch, unknown marker content, or doubt falls through to today's full check, so the fast path can only ever be as wrong as the run that recorded it.

Off by default behind `[experimental] use-workspace-freshness-cache`, and deliberately conservative for now: workspaces containing source packages never record (their freshness needs content-based source-file probes, planned as a follow-up), `--frozen`/`--locked`/dry-run never record, and the `pixi.lock` parse itself still happens. Deferring the parse on a hit requires the lock file to be loadable lazily, which is left for a follow-up.

### Open Questions

- In-memory manifest edits (the `WorkspaceMut` flows used by `pixi add`/`remove`) bypass fingerprint recording entirely for now, documented in the module docs. This is the top item to resolve before the flag can graduate; planned as a follow-up.

### How Has This Been Tested?

The probe model is a pure function and every probe kind has unit tests for match, mismatch, and unknown-kind tolerance, written before the implementation. Offline integration tests (flag enabled via the workspace's `.pixi/config.toml`) verify the marker is recorded on install, that each input mutation (manifest edit, lock edit, config change) forces the full check and re-records, and that a corrupted marker falls through cleanly. Review found and fixed two real bugs with failing-first tests: the config digest was unstable under `HashMap` iteration order, and a Ctrl-C during the outdated walk could leave a vacuously-empty result recordable as "fresh".

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.