### PR TITLE
refactor: put the lock file behind a lazy handle in LockFileDerivedData

### DIFF
--- a/crates/pixi/tests/integration_rust/common/mod.rs
+++ b/crates/pixi/tests/integration_rust/common/mod.rs
@@ -770,11 +770,12 @@ impl PixiControl {
     /// project.
     pub async fn update_lock_file(&self) -> miette::Result<LockFile> {
         let project = self.workspace()?;
-        Ok(project
+        project
             .update_lock_file(None, UpdateLockFileOptions::default())
             .await?
             .0
-            .into_lock_file())
+            .into_lock_file()
+            .await
     }
 
     /// Returns an [`LockBuilder`].

--- a/crates/pixi/tests/integration_rust/install_filter_tests.rs
+++ b/crates/pixi/tests/integration_rust/install_filter_tests.rs
@@ -77,7 +77,12 @@ async fn install_filter_skip_direct_soft_exclusion() {
     let filter = InstallFilter::new().skip_direct(vec!["a".to_string()]);
     let skipped = PackageFilterNames::new(
         &filter,
-        derived.lock_file.environment(env.name().as_str()).unwrap(),
+        derived
+            .lock_file()
+            .await
+            .unwrap()
+            .environment(env.name().as_str())
+            .unwrap(),
         env.best_declared_platform()
             .expect("no best platform for env"),
     )
@@ -105,7 +110,12 @@ async fn install_filter_skip_with_deps_hard_exclusion() {
     let filter = InstallFilter::new().skip_with_deps(vec!["a".to_string()]);
     let skipped = PackageFilterNames::new(
         &filter,
-        derived.lock_file.environment(env.name().as_str()).unwrap(),
+        derived
+            .lock_file()
+            .await
+            .unwrap()
+            .environment(env.name().as_str())
+            .unwrap(),
         env.best_declared_platform()
             .expect("no best platform for env"),
     )
@@ -140,7 +150,12 @@ async fn install_filter_target_package_zoom_in() {
     let filter = InstallFilter::new().target_packages(vec!["a".to_string()]);
     let skipped = PackageFilterNames::new(
         &filter,
-        derived.lock_file.environment(env.name().as_str()).unwrap(),
+        derived
+            .lock_file()
+            .await
+            .unwrap()
+            .environment(env.name().as_str())
+            .unwrap(),
         env.best_declared_platform()
             .expect("no best platform for env"),
     )
@@ -167,7 +182,12 @@ async fn install_filter_target_with_skip_with_deps_stop() {
         .skip_with_deps(vec!["c".to_string()]);
     let skipped = PackageFilterNames::new(
         &filter,
-        derived.lock_file.environment(env.name().as_str()).unwrap(),
+        derived
+            .lock_file()
+            .await
+            .unwrap()
+            .environment(env.name().as_str())
+            .unwrap(),
         env.best_declared_platform()
             .expect("no best platform for env"),
     )

--- a/crates/pixi/tests/integration_rust/source_package_tests.rs
+++ b/crates/pixi/tests/integration_rust/source_package_tests.rs
@@ -1378,7 +1378,7 @@ test-source-pkg = {{ path = "./source-package" }}
     assert!(was_updated, "First invocation should update the lock file");
 
     // Verify the package is in the lock file
-    let lock_file = lock_file_data.into_lock_file();
+    let lock_file = lock_file_data.into_lock_file().await.unwrap();
     assert!(
         lock_file.contains_conda_package(
             consts::DEFAULT_ENVIRONMENT_NAME,
@@ -1781,7 +1781,7 @@ my-package = {{ path = "./my-package" }}
     assert!(was_updated, "First invocation should create the lock file");
 
     // Verify the package is in the lock file
-    let lock_file = lock_file_data.into_lock_file();
+    let lock_file = lock_file_data.into_lock_file().await.unwrap();
     assert!(
         lock_file.contains_conda_package(
             consts::DEFAULT_ENVIRONMENT_NAME,
@@ -2107,7 +2107,7 @@ my-package = {{ path = "./my-package" }}
         .await
         .expect("First lock should succeed");
 
-    let lock_file = lock_file_data.into_lock_file();
+    let lock_file = lock_file_data.into_lock_file().await.unwrap();
 
     // Find the source package in the lock file.
     let env = lock_file
@@ -2161,7 +2161,7 @@ my-package = {{ path = "./my-package" }}
         "Second lock invocation should not update the lock file"
     );
 
-    let lock_file_2 = lock_file_data_2.into_lock_file();
+    let lock_file_2 = lock_file_data_2.into_lock_file().await.unwrap();
     let env_2 = lock_file_2
         .environment(consts::DEFAULT_ENVIRONMENT_NAME)
         .unwrap();
@@ -2290,7 +2290,7 @@ my-package = {{ path = "./my-package" }}
         .update_lock_file(None, pixi_core::UpdateLockFileOptions::default())
         .await
         .expect("first solve should succeed");
-    let lock_v1 = lock_data.into_lock_file();
+    let lock_v1 = lock_data.into_lock_file().await.unwrap();
     let foo_versions_v1 = collect_build_dep_versions(&lock_v1, "my-package", "foo");
     assert_eq!(
         foo_versions_v1,
@@ -2330,7 +2330,7 @@ bar = "*"
         was_updated,
         "second solve must re-lock since build-dependencies changed"
     );
-    let lock_v2 = lock_data.into_lock_file();
+    let lock_v2 = lock_data.into_lock_file().await.unwrap();
 
     let foo_versions_v2 = collect_build_dep_versions(&lock_v2, "my-package", "foo");
     assert_eq!(

--- a/crates/pixi_api/src/workspace/list/mod.rs
+++ b/crates/pixi_api/src/workspace/list/mod.rs
@@ -44,7 +44,8 @@ pub async fn list(
         )
         .await?
         .0
-        .into_lock_file();
+        .into_lock_file()
+        .await?;
 
     // Resolve the platform argument: a workspace-platform name takes
     // priority; a bare conda subdir is accepted as a fallback so the user

--- a/crates/pixi_cli/src/install.rs
+++ b/crates/pixi_cli/src/install.rs
@@ -5,7 +5,7 @@ use pixi_config::ConfigCli;
 use pixi_core::{
     UpdateLockFileOptions, WorkspaceLocator,
     environment::{InstallFilter, get_update_lock_file_and_prefixes},
-    lock_file::{LockFileDerivedData, PackageFilterNames, ReinstallPackages, UpdateMode},
+    lock_file::{PackageFilterNames, ReinstallPackages, UpdateMode},
     workspace::{HasWorkspaceRef, PlatformOverrides, PlatformSource},
 };
 use pixi_manifest::PixiPlatformName;
@@ -145,7 +145,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .target_packages(args.only.clone().unwrap_or_default());
 
     // Update the prefixes by installing all packages
-    let (LockFileDerivedData { lock_file, .. }, _) = get_update_lock_file_and_prefixes(
+    let (derived_data, _) = get_update_lock_file_and_prefixes(
         &environments,
         target_platform.as_ref(),
         Some(pixi_reporters::TopLevelProgress::from_global()),
@@ -160,6 +160,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         &filter,
     )
     .await?;
+    let lock_file = derived_data.into_lock_file().await?;
 
     // Message what's installed
     let mut message = console::style(console::Emoji("✔ ", "")).green().to_string();

--- a/crates/pixi_cli/src/lock.rs
+++ b/crates/pixi_cli/src/lock.rs
@@ -1,10 +1,6 @@
 use clap::Parser;
 use miette::{Context, IntoDiagnostic};
-use pixi_core::{
-    WorkspaceLocator,
-    environment::LockFileUsage,
-    lock_file::{LockFileDerivedData, UpdateLockFileOptions},
-};
+use pixi_core::{WorkspaceLocator, environment::LockFileUsage, lock_file::UpdateLockFileOptions};
 use pixi_diff::{LockFileDiff, LockFileJsonDiff};
 
 use crate::cli_config::NoInstallConfig;
@@ -55,7 +51,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     // Use the silent version here since update_lock_file() will display the warning.
     let original_lock_file = workspace.load_lock_file().await?.into_lock_file_or_empty();
     let progress = pixi_reporters::TopLevelProgress::from_global();
-    let (LockFileDerivedData { lock_file, .. }, lock_updated) = workspace
+    let (derived_data, lock_updated) = workspace
         .update_lock_file(
             Some(progress),
             UpdateLockFileOptions {
@@ -70,6 +66,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             },
         )
         .await?;
+    let lock_file = derived_data.into_lock_file().await?;
 
     // Determine the diff between the old and new lock file.
     let diff = LockFileDiff::from_lock_files(&original_lock_file, &lock_file);

--- a/crates/pixi_cli/src/run.rs
+++ b/crates/pixi_cli/src/run.rs
@@ -315,13 +315,13 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             && user_platform.is_none()
             && classify_environment_runnability(
                 &executable_task.run_environment,
-                Some(lock_file.as_lock_file()),
+                Some(lock_file.lock_file().await?),
             ) == EnvironmentRunnability::Unsupported
         {
             return Err(
                 match verify_current_platform_can_run_environment(
                     &executable_task.run_environment,
-                    Some(lock_file.as_lock_file()),
+                    Some(lock_file.lock_file().await?),
                 ) {
                     Err(err) => err.into(),
                     Ok(()) => executable_task
@@ -375,7 +375,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
         // check task cache
         let task_cache = match executable_task
-            .can_skip(lock_file.as_lock_file())
+            .can_skip(lock_file.lock_file().await?)
             .await
             .into_diagnostic()?
         {
@@ -435,7 +435,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 let command_env = get_task_env(
                     &executable_task.run_environment,
                     args.clean_env || executable_task.task().clean_env(),
-                    Some(lock_file.as_lock_file()),
+                    Some(lock_file.lock_file().await?),
                     workspace.config().force_activate(),
                     workspace.config().experimental_activation_cache_usage(),
                 )
@@ -467,7 +467,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
         // Compute post-run hash, warn on missing globs, and update the cache
         let post_hash = executable_task
-            .compute_post_run_hash(lock_file.as_lock_file(), task_cache)
+            .compute_post_run_hash(lock_file.lock_file().await?, task_cache)
             .await
             .into_diagnostic()?;
         if let Some(ref hash) = post_hash {

--- a/crates/pixi_cli/src/shell.rs
+++ b/crates/pixi_cli/src/shell.rs
@@ -351,7 +351,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         &InstallFilter::default(),
     )
     .await?;
-    let lock_file = lock_file_data.into_lock_file();
+    let lock_file = lock_file_data.into_lock_file().await?;
 
     // Get the environment variables we need to set activate the environment in the shell.
     let env = get_activated_environment_variables(

--- a/crates/pixi_cli/src/shell_hook.rs
+++ b/crates/pixi_cli/src/shell_hook.rs
@@ -186,7 +186,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         true => {
             generate_environment_json(
                 &environment,
-                &lock_file_data.into_lock_file(),
+                &lock_file_data.into_lock_file().await?,
                 workspace.config().force_activate(),
                 workspace.config().experimental_activation_cache_usage(),
             )

--- a/crates/pixi_cli/src/tree.rs
+++ b/crates/pixi_cli/src/tree.rs
@@ -88,7 +88,8 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .await
         .wrap_err("Failed to update lock file")?
         .0
-        .into_lock_file();
+        .into_lock_file()
+        .await?;
 
     let workspace_platforms = (&workspace)
         .workspace_manifest()

--- a/crates/pixi_cli/src/update.rs
+++ b/crates/pixi_cli/src/update.rs
@@ -182,10 +182,10 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     // If we're doing a dry-run, we don't want to write the lock file.
     if !args.dry_run {
-        updated_lock_file.write_to_disk()?;
+        updated_lock_file.write_to_disk().await?;
     }
 
-    let lock_file = updated_lock_file.into_lock_file();
+    let lock_file = updated_lock_file.into_lock_file().await?;
 
     // Determine the diff between the old and new lock file.
     let diff = LockFileDiff::from_lock_files(loaded_lock_file, &lock_file);

--- a/crates/pixi_cli/src/upgrade.rs
+++ b/crates/pixi_cli/src/upgrade.rs
@@ -224,7 +224,8 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 .await?
                 .update()
                 .await?;
-            let diff = LockFileDiff::from_lock_files(&original_lock_file, &derived.lock_file);
+            let diff =
+                LockFileDiff::from_lock_files(&original_lock_file, derived.lock_file().await?);
             let json_diff =
                 LockFileJsonDiff::new(Some(workspace.workspace().named_environments()), diff);
             let json = serde_json::to_string_pretty(&json_diff).expect("failed to convert to json");

--- a/crates/pixi_cli/src/workspace/export/conda_explicit_spec.rs
+++ b/crates/pixi_cli/src/workspace/export/conda_explicit_spec.rs
@@ -192,7 +192,8 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         )
         .await?
         .0
-        .into_lock_file();
+        .into_lock_file()
+        .await?;
 
     let mut environments = Vec::new();
     if let Some(env_names) = args.environment {

--- a/crates/pixi_core/src/lock_file/lazy_lock_file.rs
+++ b/crates/pixi_core/src/lock_file/lazy_lock_file.rs
@@ -1,0 +1,248 @@
+//! A lazily-parsed handle around the workspace lock file.
+//!
+//! [`LazyLockFile`] lets [`LockFileDerivedData`] hold either an already
+//! parsed [`LockFile`] or only the on-disk location of one, deferring the
+//! YAML parse until a consumer actually needs the lock file's contents. A
+//! fast path that can prove the lock file is unchanged can hand out an
+//! unloaded handle and skip the parse entirely unless the contents are
+//! actually used.
+//!
+//! [`LockFileDerivedData`]: super::LockFileDerivedData
+
+use std::path::PathBuf;
+
+use pixi_manifest::WorkspaceManifest;
+use rattler_lock::LockFile;
+
+use super::update::load_lock_file_from_path;
+
+/// The on-disk source of a lock file that has not been parsed yet.
+///
+/// Next to the path this carries the same context that
+/// [`crate::Workspace::load_lock_file`] captures: after parsing, locked
+/// platform names are realigned to the manifest's current platform names.
+#[derive(Clone)]
+struct UnloadedLockFile {
+    /// The path to the lock file on disk.
+    path: PathBuf,
+    /// The manifest whose platform names the parsed lock file is aligned to.
+    manifest: WorkspaceManifest,
+    /// The workspace root, used to resolve relative paths while aligning
+    /// platform names.
+    workspace_root: PathBuf,
+}
+
+impl UnloadedLockFile {
+    /// Parses the lock file from disk, mirroring the semantics of
+    /// [`crate::Workspace::load_lock_file`] followed by the graceful
+    /// version-mismatch handling of `update_lock_file`: a missing file
+    /// yields an empty lock file, and a lock file whose version is newer
+    /// than supported prints a warning and also falls back to an empty one.
+    async fn load(self) -> miette::Result<LockFile> {
+        load_lock_file_from_path(self.path, self.manifest, self.workspace_root)
+            .await
+            .map(|result| result.into_lock_file_or_empty_with_warning())
+    }
+}
+
+/// The two states of a [`LazyLockFile`].
+enum State {
+    /// The lock file is already parsed.
+    Loaded(LockFile),
+    /// The lock file has not been parsed yet: `cell` caches the parse of
+    /// `source` on first access. The source is boxed because the manifest
+    /// it carries dwarfs the `Loaded` variant.
+    Unloaded {
+        cell: async_once_cell::OnceCell<LockFile>,
+        source: Box<UnloadedLockFile>,
+    },
+}
+
+/// A [`LockFile`] that is either already parsed or is parsed from disk on
+/// first access.
+///
+/// An `Unloaded(path) | Loaded(LockFile)` handle: [`LazyLockFile::loaded`]
+/// wraps an already parsed lock file while [`LazyLockFile::unloaded`] only
+/// records where to find one. Loading goes through the same machinery as
+/// [`crate::Workspace::load_lock_file`] (platform-name alignment included),
+/// followed by `update_lock_file`'s *graceful* version-mismatch handling: a
+/// lock file version newer than supported warns and falls back to an empty
+/// lock file. The `--locked`/`--frozen` strictness that turns such a
+/// mismatch into a hard error instead is applied by `update_lock_file`
+/// before any handle exists; callers that need it must gate before handing
+/// out an unloaded handle.
+pub struct LazyLockFile {
+    /// Whether the lock file is parsed already, and if not, where to load
+    /// it from.
+    state: State,
+}
+
+impl LazyLockFile {
+    /// Wraps an already parsed lock file. Accessors never touch the
+    /// filesystem.
+    pub fn loaded(lock_file: LockFile) -> Self {
+        Self {
+            state: State::Loaded(lock_file),
+        }
+    }
+
+    /// Constructs a handle that parses the lock file at `path` on first
+    /// access. `manifest` and `workspace_root` provide the platform-name
+    /// alignment context that [`crate::Workspace::load_lock_file`] also
+    /// applies after parsing.
+    pub fn unloaded(path: PathBuf, manifest: WorkspaceManifest, workspace_root: PathBuf) -> Self {
+        Self {
+            state: State::Unloaded {
+                cell: async_once_cell::OnceCell::new(),
+                source: Box::new(UnloadedLockFile {
+                    path,
+                    manifest,
+                    workspace_root,
+                }),
+            },
+        }
+    }
+
+    /// Returns the lock file, parsing it from disk on first access when this
+    /// handle was constructed with [`Self::unloaded`]. Concurrent callers
+    /// share a single parse, and every call after the first returns the
+    /// cached instance.
+    pub async fn get(&self) -> miette::Result<&LockFile> {
+        match &self.state {
+            State::Loaded(lock_file) => Ok(lock_file),
+            State::Unloaded { cell, source } => {
+                cell.get_or_try_init(async {
+                    // Clone out of the shared handle: parsing hands the
+                    // context to a blocking task, which needs ownership.
+                    source.as_ref().clone().load().await
+                })
+                .await
+            }
+        }
+    }
+
+    /// Consumes the handle and returns the lock file, parsing it from disk
+    /// first when it has not been accessed before.
+    pub async fn into_inner(self) -> miette::Result<LockFile> {
+        match self.state {
+            State::Loaded(lock_file) => Ok(lock_file),
+            State::Unloaded { cell, source } => match cell.into_inner() {
+                Some(lock_file) => Ok(lock_file),
+                None => (*source).load().await,
+            },
+        }
+    }
+
+    /// Returns the lock file if it has already been parsed, without
+    /// triggering a load. For synchronous contexts that can tolerate the
+    /// lock file's absence.
+    pub fn as_loaded(&self) -> Option<&LockFile> {
+        match &self.state {
+            State::Loaded(lock_file) => Some(lock_file),
+            State::Unloaded { cell, .. } => cell.get(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use pixi_manifest::{HasWorkspaceManifest as _, WorkspaceManifest};
+    use rattler_lock::LockFile;
+
+    use super::LazyLockFile;
+    use crate::Workspace;
+
+    /// A minimal workspace manifest supplying the platform-name alignment
+    /// context that loading a lock file from disk requires.
+    fn test_manifest(root: &Path) -> WorkspaceManifest {
+        let manifest_toml = r#"
+        [project]
+        name = "lazy-lock-file-test"
+        channels = []
+        platforms = []
+        "#;
+        let workspace =
+            Workspace::from_str(root.join("pixi.toml").as_path(), manifest_toml).unwrap();
+        (&workspace).workspace_manifest().clone()
+    }
+
+    /// A lock file with a recognizable environment so tests can tell a lock
+    /// file parsed from disk apart from `LockFile::default()`.
+    fn distinctive_lock_file() -> LockFile {
+        LockFile::builder()
+            .with_channels("lazy-test-env", Vec::<rattler_lock::Channel>::new())
+            .finish()
+    }
+
+    #[tokio::test]
+    async fn loaded_get_returns_the_lock_file_without_touching_the_filesystem() {
+        let lazy = LazyLockFile::loaded(distinctive_lock_file());
+
+        // The value is available synchronously; there is no on-disk source
+        // that could be consulted.
+        assert!(lazy.as_loaded().is_some());
+        let lock_file = lazy.get().await.unwrap();
+        assert!(lock_file.environment("lazy-test-env").is_some());
+    }
+
+    #[tokio::test]
+    async fn unloaded_get_parses_the_lock_file_once() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lock_file_path = tmp.path().join("pixi.lock");
+        distinctive_lock_file().to_path(&lock_file_path).unwrap();
+
+        let lazy = LazyLockFile::unloaded(
+            lock_file_path,
+            test_manifest(tmp.path()),
+            tmp.path().to_path_buf(),
+        );
+        assert!(lazy.as_loaded().is_none());
+
+        // The first access parses the file from disk.
+        let first = lazy.get().await.unwrap();
+        assert!(first.environment("lazy-test-env").is_some());
+
+        // The second access returns the cached instance (`OnceCell`
+        // semantics), not a re-parse.
+        let second = lazy.get().await.unwrap();
+        assert!(std::ptr::eq(first, second));
+        assert!(lazy.as_loaded().is_some());
+    }
+
+    #[tokio::test]
+    async fn unloaded_get_falls_back_to_an_empty_lock_file_when_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lazy = LazyLockFile::unloaded(
+            tmp.path().join("does-not-exist").join("pixi.lock"),
+            test_manifest(tmp.path()),
+            tmp.path().to_path_buf(),
+        );
+
+        // Mirrors `Workspace::load_lock_file`: a missing lock file behaves
+        // like an empty one instead of erroring.
+        let lock_file = lazy.get().await.unwrap();
+        assert_eq!(lock_file.environments().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn into_inner_returns_the_lock_file_in_both_states() {
+        // Loaded: hands back the value without any I/O.
+        let loaded = LazyLockFile::loaded(distinctive_lock_file());
+        let lock_file = loaded.into_inner().await.unwrap();
+        assert!(lock_file.environment("lazy-test-env").is_some());
+
+        // Unloaded: parses from disk on consumption.
+        let tmp = tempfile::tempdir().unwrap();
+        let lock_file_path = tmp.path().join("pixi.lock");
+        distinctive_lock_file().to_path(&lock_file_path).unwrap();
+        let unloaded = LazyLockFile::unloaded(
+            lock_file_path,
+            test_manifest(tmp.path()),
+            tmp.path().to_path_buf(),
+        );
+        let lock_file = unloaded.into_inner().await.unwrap();
+        assert!(lock_file.environment("lazy-test-env").is_some());
+    }
+}

--- a/crates/pixi_core/src/lock_file/mod.rs
+++ b/crates/pixi_core/src/lock_file/mod.rs
@@ -1,4 +1,5 @@
 mod install_subset;
+mod lazy_lock_file;
 mod outdated;
 mod package_identifier;
 mod platform_rename;
@@ -13,6 +14,7 @@ pub mod virtual_packages;
 
 pub use crate::environment::CondaPrefixUpdater;
 pub use install_subset::{FilteredPackages, InstallSubset};
+pub use lazy_lock_file::LazyLockFile;
 pub use package_identifier::PypiPackageIdentifier;
 use pixi_install_pypi::LockedPypiRecord;
 use pixi_record::PixiRecord;

--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -37,7 +37,7 @@ use pixi_install_pypi::{
 };
 use pixi_manifest::{
     ChannelPriority, EnvironmentName, FeaturesExt, HasWorkspaceManifest, PixiPlatform,
-    PixiPlatformName,
+    PixiPlatformName, WorkspaceManifest,
 };
 use pixi_progress::global_multi_progress;
 use pixi_record::{LockFileResolver, ParseLockFileError, PixiRecord, UnresolvedPixiRecord};
@@ -60,7 +60,7 @@ use uv_install_wheel::LinkMode;
 use uv_normalize::ExtraName;
 
 use super::{
-    CondaPrefixUpdater, InstallSubset, PixiRecordsByName, PypiRecordsByName,
+    CondaPrefixUpdater, InstallSubset, LazyLockFile, PixiRecordsByName, PypiRecordsByName,
     UnresolvedPixiRecordsByName, outdated::OutdatedEnvironments, resolve_lock_platform,
     utils::IoConcurrencyLimit,
 };
@@ -277,7 +277,8 @@ impl Workspace {
         // Load the lock file, displaying warning if there's a version mismatch
         let lock_file = lock_file_result.into_lock_file_or_empty_with_warning();
 
-        let needs_format_upgrade = lock_file.version() < rattler_lock::FileFormatVersion::LATEST;
+        let lock_file_version = lock_file.version();
+        let needs_format_upgrade = lock_file_version < rattler_lock::FileFormatVersion::LATEST;
 
         let glob_hash_cache = GlobHashCache::default();
 
@@ -308,11 +309,11 @@ impl Workspace {
         }
 
         // Check which environments are out of date.
-        let resolver = derived.resolver()?;
+        let resolver = derived.resolver().await?;
         let mut outdated = OutdatedEnvironments::from_workspace_and_lock_file(
             self,
             command_dispatcher.clone(),
-            &derived.lock_file,
+            derived.lock_file().await?,
             &resolver,
         )
         .await;
@@ -321,7 +322,7 @@ impl Workspace {
                 tracing::warn!(
                     "the lock file is up-to-date but uses an older format (v{}), \
                      run `pixi lock` to upgrade to v{} for improved reproducibility",
-                    derived.lock_file.version(),
+                    lock_file_version,
                     rattler_lock::FileFormatVersion::LATEST,
                 );
             } else {
@@ -349,7 +350,7 @@ impl Workspace {
             tracing::warn!(
                 "the lock file is up-to-date but uses an older format (v{}), \
                  re-solving all environments using locked content to upgrade to v{}",
-                derived.lock_file.version(),
+                lock_file_version,
                 rattler_lock::FileFormatVersion::LATEST,
             );
             for env in self.environments() {
@@ -384,6 +385,7 @@ impl Workspace {
             glob_hash_cache,
             ..
         } = derived;
+        let lock_file = lock_file.into_inner().await?;
 
         // Construct an update context and perform the actual update.
         let lock_file_derived_data = UpdateContext::builder(self, command_dispatcher)?
@@ -400,13 +402,13 @@ impl Workspace {
 
         warn_unknown_requested_extras(
             &solved_conda_environments,
-            &lock_file_derived_data.lock_file,
+            lock_file_derived_data.lock_file().await?,
         );
 
         // Write the lock file to disk
 
         if options.lock_file_usage != LockFileUsage::DryRun {
-            lock_file_derived_data.write_to_disk()?;
+            lock_file_derived_data.write_to_disk().await?;
         }
 
         Ok((lock_file_derived_data, true))
@@ -424,50 +426,67 @@ impl Workspace {
     /// - `.into_lock_file_or_empty()` - silent fallback to empty
     /// - `.into_lock_file_or_empty_with_warning()` - displays warning and continues
     pub async fn load_lock_file(&self) -> miette::Result<LockFileLoadResult> {
-        let lock_file_path = self.lock_file_path();
-        let manifest = self.workspace_manifest().clone();
-        let workspace_root = self.root().to_path_buf();
-        if lock_file_path.is_file() {
-            // Spawn a background task because loading the file might be IO bound.
-            tokio::task::spawn_blocking(move || {
-                LockFile::from_path(&lock_file_path)
-                    .map(|lock| {
-                        // Rewrite locked platform names to match the manifest's
-                        // current platforms by identity (subdir + customised
-                        // virtual packages). A user who renames an entry in
-                        // pixi.toml shouldn't have to re-solve to use the
-                        // existing locked packages, and downstream code
-                        // (satisfiability, environment lookup, install) sees
-                        // the workspace-current names directly.
-                        crate::lock_file::platform_rename::align_platform_names(
-                            lock,
-                            &manifest,
-                            &workspace_root,
-                        )
-                    })
-                    .map(LockFileLoadResult::Loaded)
-                    .or_else(|err| match err {
-                        ParseCondaLockError::IncompatibleVersion {
-                            lock_file_version,
-                            max_supported_version,
-                        } => Ok(LockFileLoadResult::VersionMismatch {
-                            lock_file_version,
-                            max_supported_version,
-                        }),
-                        _ => Err(miette::miette!(err)),
-                    })
-                    .wrap_err_with(|| {
-                        format!(
-                            "Failed to load lock file from `{}`",
-                            lock_file_path.display()
-                        )
-                    })
-            })
-            .await
-            .unwrap_or_else(|e| Err(e).into_diagnostic())
-        } else {
-            Ok(LockFileLoadResult::Loaded(LockFile::default()))
-        }
+        load_lock_file_from_path(
+            self.lock_file_path(),
+            self.workspace_manifest().clone(),
+            self.root().to_path_buf(),
+        )
+        .await
+    }
+}
+
+/// Loads the lock file at `lock_file_path` from disk. This is the loading
+/// machinery behind [`Workspace::load_lock_file`] and
+/// [`super::LazyLockFile`]; see the former for the returned variants.
+///
+/// `manifest` and `workspace_root` provide the platform-name alignment
+/// context: locked platform names are rewritten to the manifest's current
+/// names after parsing.
+pub(crate) async fn load_lock_file_from_path(
+    lock_file_path: PathBuf,
+    manifest: WorkspaceManifest,
+    workspace_root: PathBuf,
+) -> miette::Result<LockFileLoadResult> {
+    if lock_file_path.is_file() {
+        // Spawn a background task because loading the file might be IO bound.
+        tokio::task::spawn_blocking(move || {
+            LockFile::from_path(&lock_file_path)
+                .map(|lock| {
+                    // Rewrite locked platform names to match the manifest's
+                    // current platforms by identity (subdir + customised
+                    // virtual packages). A user who renames an entry in
+                    // pixi.toml shouldn't have to re-solve to use the
+                    // existing locked packages, and downstream code
+                    // (satisfiability, environment lookup, install) sees
+                    // the workspace-current names directly.
+                    crate::lock_file::platform_rename::align_platform_names(
+                        lock,
+                        &manifest,
+                        &workspace_root,
+                    )
+                })
+                .map(LockFileLoadResult::Loaded)
+                .or_else(|err| match err {
+                    ParseCondaLockError::IncompatibleVersion {
+                        lock_file_version,
+                        max_supported_version,
+                    } => Ok(LockFileLoadResult::VersionMismatch {
+                        lock_file_version,
+                        max_supported_version,
+                    }),
+                    _ => Err(miette::miette!(err)),
+                })
+                .wrap_err_with(|| {
+                    format!(
+                        "Failed to load lock file from `{}`",
+                        lock_file_path.display()
+                    )
+                })
+        })
+        .await
+        .unwrap_or_else(|e| Err(e).into_diagnostic())
+    } else {
+        Ok(LockFileLoadResult::Loaded(LockFile::default()))
     }
 }
 
@@ -570,11 +589,13 @@ pub struct LockFileDerivedData<'p> {
     /// satisfaction check that would otherwise reject them.
     pub target_platform: Option<PixiPlatformName>,
 
-    /// The lock file
+    /// The lock file, either already parsed or pending an on-demand parse.
     ///
-    /// Prefer to use `as_lock_file` or `into_lock_file` to also make a decision
-    /// what to do with the resources used to create this instance.
-    pub lock_file: LockFile,
+    /// Prefer to use [`Self::lock_file`] or [`Self::into_lock_file`] to also
+    /// make a decision what to do with the resources used to create this
+    /// instance. The field is `pub(crate)` (rather than private) only so
+    /// in-crate callers can move the handle out by destructuring.
+    pub(crate) lock_file: LazyLockFile,
 
     /// The package cache
     pub package_cache: PackageCache,
@@ -637,6 +658,53 @@ impl<'p> LockFileDerivedData<'p> {
         command_dispatcher: CommandDispatcher,
         glob_hash_cache: GlobHashCache,
     ) -> Self {
+        Self::from_lazy_lock_file(
+            workspace,
+            LazyLockFile::loaded(lock_file),
+            package_cache,
+            command_dispatcher,
+            glob_hash_cache,
+        )
+    }
+
+    /// Construct a derived-data wrapper like [`Self::from_input_lock_file`],
+    /// except that the lock file is not parsed yet: it is loaded from the
+    /// workspace's lock file path on first access. Intended for fast paths
+    /// that can prove the lock file on disk is up-to-date without parsing it.
+    ///
+    /// Loading through the handle applies `update_lock_file`'s *graceful*
+    /// version-mismatch handling (warn and fall back to an empty lock file);
+    /// a caller that must honor `--locked`/`--frozen` strictness has to gate
+    /// on that before constructing the unloaded handle, exactly like
+    /// `update_lock_file` does before constructing a loaded one.
+    pub fn from_unloaded_lock_file(
+        workspace: &'p Workspace,
+        package_cache: PackageCache,
+        command_dispatcher: CommandDispatcher,
+        glob_hash_cache: GlobHashCache,
+    ) -> Self {
+        Self::from_lazy_lock_file(
+            workspace,
+            LazyLockFile::unloaded(
+                workspace.lock_file_path(),
+                workspace.workspace_manifest().clone(),
+                workspace.root().to_path_buf(),
+            ),
+            package_cache,
+            command_dispatcher,
+            glob_hash_cache,
+        )
+    }
+
+    /// Shared constructor behind [`Self::from_input_lock_file`] and
+    /// [`Self::from_unloaded_lock_file`].
+    fn from_lazy_lock_file(
+        workspace: &'p Workspace,
+        lock_file: LazyLockFile,
+        package_cache: PackageCache,
+        command_dispatcher: CommandDispatcher,
+        glob_hash_cache: GlobHashCache,
+    ) -> Self {
         Self {
             workspace,
             target_platform: None,
@@ -654,11 +722,19 @@ impl<'p> LockFileDerivedData<'p> {
     }
 
     /// Returns a resolver for the current lock file, building it on first
-    /// access and caching the result.
-    pub fn resolver(&self) -> miette::Result<Arc<LockFileResolver>> {
+    /// access and caching the result. Building parses the lock file from
+    /// disk first when it is not loaded yet; a cached (or seeded) resolver
+    /// is returned without touching the lock file.
+    pub async fn resolver(&self) -> miette::Result<Arc<LockFileResolver>> {
+        // Check the cache before the lock file: an unloaded lock file must
+        // not be parsed just to return an already-built resolver.
+        if let Some(resolver) = self.resolver.get() {
+            return Ok(resolver.clone());
+        }
+        let lock_file = self.lock_file().await?;
         self.resolver
             .get_or_try_init(|| {
-                LockFileResolver::build(&self.lock_file, self.workspace.root())
+                LockFileResolver::build(lock_file, self.workspace.root())
                     .map(Arc::new)
                     .into_diagnostic()
             })
@@ -675,13 +751,14 @@ impl<'p> LockFileDerivedData<'p> {
         let _ = self.resolver.set(resolver);
     }
 
-    /// Write the lock file to disk.
-    pub fn write_to_disk(&self) -> miette::Result<()> {
+    /// Write the lock file to disk. Parses the lock file from disk first when
+    /// it is not loaded yet.
+    pub async fn write_to_disk(&self) -> miette::Result<()> {
         let lock_file_path = self.workspace.lock_file_path();
         // Shorten rich platform names to `p1`, `p2`, ... on disk; the load-time
         // pass restores the manifest names by identity.
         let lock_file = crate::lock_file::platform_rename::shorten_platform_names(
-            self.lock_file.clone(),
+            self.lock_file().await?.clone(),
             self.workspace.workspace_manifest(),
             self.workspace.root(),
         );
@@ -692,24 +769,26 @@ impl<'p> LockFileDerivedData<'p> {
     }
 
     /// Consumes this instance, dropping any resources that are not needed
-    /// anymore to work with the lock file.
-    pub fn into_lock_file(self) -> LockFile {
-        self.lock_file
+    /// anymore to work with the lock file. Parses the lock file from disk
+    /// first when it was constructed unloaded and never accessed.
+    pub async fn into_lock_file(self) -> miette::Result<LockFile> {
+        self.lock_file.into_inner().await
     }
 
     /// Returns a reference to the internal lock file but does not consume any
     /// build resources, this is useful if you want to keep using the original
-    /// instance.
-    pub fn as_lock_file(&self) -> &LockFile {
-        &self.lock_file
+    /// instance. Parses the lock file from disk on first access when this
+    /// instance was constructed unloaded.
+    pub async fn lock_file(&self) -> miette::Result<&LockFile> {
+        self.lock_file.get().await
     }
 
     fn locked_environment_hash(
         &self,
+        lock_file: &LockFile,
         environment: &Environment<'p>,
     ) -> miette::Result<LockedEnvironmentHash> {
-        let locked_environment = self
-            .lock_file
+        let locked_environment = lock_file
             .environment(environment.name().as_str())
             .ok_or_else(|| UpdateError::LockFileMissingEnv(environment.name().clone()))?;
         Ok(LockedEnvironmentHash::from_environment(
@@ -722,7 +801,11 @@ impl<'p> LockFileDerivedData<'p> {
     /// `--platform` override or the best declared platform; when neither
     /// matches this machine, a declared platform whose lock-resolved minimum
     /// requirements the machine meets (running "by accident").
-    fn install_platform(&self, environment: &Environment<'p>) -> Option<&'p PixiPlatform> {
+    fn install_platform(
+        &self,
+        lock_file: &LockFile,
+        environment: &Environment<'p>,
+    ) -> Option<&'p PixiPlatform> {
         let target_override = self.target_platform.as_ref();
         environment
             .named_or_best_declared_platform(target_override)
@@ -730,8 +813,7 @@ impl<'p> LockFileDerivedData<'p> {
                 if target_override.is_some() {
                     return None;
                 }
-                let fallback =
-                    minimum_compatible_declared_platform(environment, &self.lock_file).ok();
+                let fallback = minimum_compatible_declared_platform(environment, lock_file).ok();
                 if let Some(platform) = fallback {
                     tracing::debug!(
                         "no declared platform of environment '{}' matches this machine; \
@@ -750,11 +832,12 @@ impl<'p> LockFileDerivedData<'p> {
     /// no declared platform runs on this machine.
     fn installed_platform_data(
         &self,
+        lock_file: &LockFile,
         environment: &Environment<'p>,
     ) -> Option<(PlatformData, PlatformData)> {
-        let resolved = self.install_platform(environment)?;
+        let resolved = self.install_platform(lock_file, environment)?;
         let minimal =
-            compute_minimal_required_platforms(&self.lock_file, environment.name(), &[resolved]);
+            compute_minimal_required_platforms(lock_file, environment.name(), &[resolved]);
         // A subdir whose lock entry has no conda packages is absent from the
         // map; the minimum is then the subdir with no required virtual packages.
         let minimum = minimal.get(&resolved.subdir()).map_or_else(
@@ -777,9 +860,10 @@ impl<'p> LockFileDerivedData<'p> {
     ) -> miette::Result<Prefix> {
         // Check if the prefix is already up-to-date by validating the hash with the
         // environment file
-        let hash = self.locked_environment_hash(environment)?;
+        let lock_file = self.lock_file().await?;
+        let hash = self.locked_environment_hash(lock_file, environment)?;
         if update_mode == UpdateMode::QuickValidate
-            && let Some(prefix) = self.cached_prefix(environment, &hash)
+            && let Some(prefix) = self.cached_prefix(lock_file, environment, &hash)
         {
             return prefix;
         }
@@ -800,7 +884,7 @@ impl<'p> LockFileDerivedData<'p> {
         // Save an environment file to the environment directory after the update.
         // Avoiding writing the cache away before the update is done.
         let (resolved_platform, minimum_supported_platform) =
-            self.installed_platform_data(environment).unzip();
+            self.installed_platform_data(lock_file, environment).unzip();
         write_environment_file(
             &environment.dir(),
             EnvironmentFile {
@@ -844,6 +928,7 @@ impl<'p> LockFileDerivedData<'p> {
 
     fn cached_prefix(
         &self,
+        lock_file: &LockFile,
         environment: &Environment<'p>,
         hash: &LockedEnvironmentHash,
     ) -> Option<Result<Prefix, Report>> {
@@ -858,8 +943,8 @@ impl<'p> LockFileDerivedData<'p> {
         if environment_file.environment_lock_file_hash == *hash {
             // If we contain source packages from conda or PyPI we update the prefix by
             // default
-            let contains_conda_source_pkgs = self.lock_file.environments().any(|(_, env)| {
-                self.lock_file
+            let contains_conda_source_pkgs = lock_file.environments().any(|(_, env)| {
+                lock_file
                     .platform(&Platform::current().to_string())
                     .and_then(|p| env.conda_packages(p))
                     .is_some_and(|mut packages| {
@@ -908,15 +993,17 @@ impl<'p> LockFileDerivedData<'p> {
             .get_or_try_init(async {
                 let start = Instant::now();
 
+                let lock_file = self.lock_file().await?;
+
                 // Skip the host-VP validation when `--platform` pins a target the
                 // local machine can't satisfy -- that's the case the override exists for.
                 let target_override = self.target_platform.as_ref();
-                let best_declared_platform = self.install_platform(environment).ok_or_else(|| {
+                let best_declared_platform = self.install_platform(lock_file, environment).ok_or_else(|| {
                     // Prefer the requirement-level diagnosis (which platforms
                     // and virtual packages are unmet) over a generic message.
                     match verify_current_platform_can_run_environment(
                         environment,
-                        Some(&self.lock_file),
+                        Some(lock_file),
                     ) {
                         Err(err) => miette::Report::new(err).wrap_err(format!(
                             "Cannot install environment '{}'",
@@ -930,7 +1017,7 @@ impl<'p> LockFileDerivedData<'p> {
                 })?;
                 if target_override.is_none() {
                     validate_system_meets_environment_requirements(
-                        &self.lock_file,
+                        lock_file,
                         best_declared_platform,
                         environment.name(),
                         None,
@@ -942,7 +1029,7 @@ impl<'p> LockFileDerivedData<'p> {
                 }
 
                 let platform = best_declared_platform;
-                let locked_env = self.locked_env(environment)?;
+                let locked_env = self.locked_env(lock_file, environment)?;
                 let subset = InstallSubset::new(
                     &filter.skip_with_deps,
                     &filter.skip_direct,
@@ -951,7 +1038,7 @@ impl<'p> LockFileDerivedData<'p> {
                 // Fall back to the base subdir so a pre-rich, base-keyed lock still
                 // resolves when the install platform is rich (e.g. `osx-arm64-macos-12-0`).
                 let lock_platform = resolve_lock_platform(
-                    &self.lock_file,
+                    lock_file,
                     platform.name(),
                     environment.workspace_manifest(),
                 );
@@ -970,7 +1057,7 @@ impl<'p> LockFileDerivedData<'p> {
                         LockedPackage::Pypi(data) => Either::Right(data.name().clone()),
                     });
 
-                let resolver = self.resolver()?;
+                let resolver = self.resolver().await?;
                 let pixi_records = locked_packages_to_unresolved_records(conda_packages, &resolver);
 
                 // Get the manifest's pypi dependencies for this environment to look up editability.
@@ -1071,7 +1158,10 @@ impl<'p> LockFileDerivedData<'p> {
 
                 // Update the prefix with Pypi records
                 {
-                    let pypi_indexes = self.locked_env(environment)?.pypi_indexes().cloned();
+                    let pypi_indexes = self
+                        .locked_env(lock_file, environment)?
+                        .pypi_indexes()
+                        .cloned();
                     let index_strategy = environment.pypi_options().index_strategy.clone();
                     let pypi_exclude_newer = environment.pypi_exclude_newer_config_resolved();
                     let skip_wheel_filename_check =
@@ -1138,11 +1228,12 @@ impl<'p> LockFileDerivedData<'p> {
             .cloned()
     }
 
-    fn locked_env(
+    fn locked_env<'l>(
         &self,
+        lock_file: &'l LockFile,
         environment: &Environment<'p>,
-    ) -> Result<rattler_lock::Environment<'_>, UpdateError> {
-        self.lock_file
+    ) -> Result<rattler_lock::Environment<'l>, UpdateError> {
+        lock_file
             .environment(environment.name().as_str())
             .ok_or_else(|| UpdateError::LockFileMissingEnv(environment.name().clone()))
     }
@@ -1161,6 +1252,8 @@ impl<'p> LockFileDerivedData<'p> {
             .clone();
         prefix_once_cell
             .get_or_try_init(async {
+                let lock_file = self.lock_file().await?;
+
                 // Create object to update the prefix
                 let group = GroupedEnvironment::Environment(environment.clone());
                 let pixi_platform = environment
@@ -1200,11 +1293,11 @@ impl<'p> LockFileDerivedData<'p> {
                 };
 
                 // Get the locked environment from the lock file.
-                let locked_env = self.locked_env(environment)?;
+                let locked_env = self.locked_env(lock_file, environment)?;
                 // Same base-subdir fallback as the pypi prefix update above, for a
                 // rich `pixi_platform` against a pre-rich, base-keyed lock.
                 let lock_platform = resolve_lock_platform(
-                    &self.lock_file,
+                    lock_file,
                     pixi_platform.name(),
                     environment.workspace_manifest(),
                 );
@@ -1218,7 +1311,7 @@ impl<'p> LockFileDerivedData<'p> {
                 // source records are NOT resolved here — they are passed
                 // directly to the installer which builds them using
                 // variant-based output matching.
-                let resolver = self.resolver()?;
+                let resolver = self.resolver().await?;
                 let mut records = locked_packages_to_unresolved_records(packages, &resolver);
 
                 // Reify pre-v7 source envs in the records before
@@ -1241,7 +1334,7 @@ impl<'p> LockFileDerivedData<'p> {
                 lock_file::satisfiability::legacy::reify_legacy_source_envs(
                     &self.command_dispatcher,
                     &mut records,
-                    self.lock_file.version(),
+                    lock_file.version(),
                     &setup.workspace_env_ref,
                 )
                 .await
@@ -1817,7 +1910,7 @@ impl<'p> UpdateContextBuilder<'p> {
         if let Some(resolver) = self.resolver {
             input.seed_resolver(resolver);
         }
-        let resolver = input.resolver()?;
+        let resolver = input.resolver().await?;
 
         let mut outdated = match self.outdated_environments {
             Some(outdated) => outdated,
@@ -1825,13 +1918,13 @@ impl<'p> UpdateContextBuilder<'p> {
                 OutdatedEnvironments::from_workspace_and_lock_file(
                     project,
                     self.command_dispatcher.clone(),
-                    &input.lock_file,
+                    input.lock_file().await?,
                     &resolver,
                 )
                 .await
             }
         };
-        let lock_file = input.lock_file;
+        let lock_file = input.into_lock_file().await?;
 
         // Key locked conda records by the env's declared (possibly rich) platform
         // names so pre-rich, base-subdir-keyed lock files still feed rich lookups.
@@ -2668,7 +2761,7 @@ impl<'p> UpdateContext<'p> {
         Ok(LockFileDerivedData {
             workspace: project,
             target_platform: None,
-            lock_file,
+            lock_file: LazyLockFile::loaded(lock_file),
             updated_conda_prefixes: self
                 .take_instantiated_conda_prefixes()
                 .into_iter()

--- a/crates/pixi_core/src/workspace/workspace_mut.rs
+++ b/crates/pixi_core/src/workspace/workspace_mut.rs
@@ -439,6 +439,9 @@ impl WorkspaceMut {
             }
             e
         })?;
+        // The update flow always finishes with a parsed lock file, so this
+        // just unwraps the handle.
+        let lock_file = lock_file.into_inner().await?;
 
         let mut implicit_constraints = HashMap::new();
         if !conda_specs_to_add_constraints_for.is_empty() {
@@ -486,7 +489,7 @@ impl WorkspaceMut {
         updated_lock_file.io_concurrency_limit = io_concurrency_limit;
         updated_lock_file.build_caches = build_caches;
         if !dry_run {
-            updated_lock_file.write_to_disk()?;
+            updated_lock_file.write_to_disk().await?;
         }
         if !no_install
             && !dry_run
@@ -516,8 +519,10 @@ impl WorkspaceMut {
             }
         }
 
-        let lock_file_diff =
-            LockFileDiff::from_lock_files(&original_lock_file, &updated_lock_file.into_lock_file());
+        let lock_file_diff = LockFileDiff::from_lock_files(
+            &original_lock_file,
+            &updated_lock_file.into_lock_file().await?,
+        );
 
         Ok(Some(UpdateDeps {
             implicit_constraints,


### PR DESCRIPTION
### Description

The parsed lock file is an eager field on `LockFileDerivedData`: every command pays the full YAML parse of `pixi.lock` before any freshness decision can be made, because the type demands a parsed lock up front. For workspaces with large lock files that parse is a fixed per-invocation cost, paid even by commands that never end up looking inside the lock at all.

This puts the lock file behind a lazy handle. Consumers that need the parsed lock go through an accessor that loads it on first use; consumers that don't never trigger the parse. In this PR production code always constructs the handle in the loaded state, so behavior today is byte-identical, deliberately. The risky part of this change is the accessor migration across every consumer, and that churn is best reviewed while the full test suite can prove behavior is unchanged. A small follow-up can then construct the handle unloaded on paths that have already established freshness by other means, which is where the parse actually disappears.

### Open Questions

- The async-coloring of the accessors lands ahead of its payoff: with the handle always loaded, every `await` on it resolves immediately. Merging the churn now, byte-identical and fully tested, keeps the follow-up that enables the win small and reviewable. It does mean this PR is temporarily "abstraction without benefit" on its own.

### How Has This Been Tested?

The handle itself has unit tests for both states, written before the implementation: loaded returns without touching the filesystem, unloaded parses once and caches, and a missing file yields an empty lock, matching today's semantics. The migration is compile-driven, and the full offline unit and integration suites pass with results byte-identical to the unmodified base commit. The single failing test is a pre-existing tracing-subscriber race, reproduced on base in a scratch worktree.

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.