### PR TITLE
refactor: drop the unused lock-file parameter from the activation path

### DIFF
--- a/crates/pixi/tests/integration_rust/common/mod.rs
+++ b/crates/pixi/tests/integration_rust/common/mod.rs
@@ -676,8 +676,7 @@ impl PixiControl {
                         )
                         .await?;
                     let env =
-                        get_task_env(&task.run_environment, args.clean_env, None, false, false)
-                            .await?;
+                        get_task_env(&task.run_environment, args.clean_env, false, false).await?;
                     task_env.insert(env)
                 }
                 Some(task_env) => task_env,

--- a/crates/pixi/tests/integration_rust/test_activation.rs
+++ b/crates/pixi/tests/integration_rust/test_activation.rs
@@ -23,7 +23,6 @@ async fn test_pixi_only_env_activation() {
         workspace.env_vars(),
         &default_env,
         CurrentEnvVarBehavior::Exclude,
-        None,
         false,
         false,
     )
@@ -62,7 +61,6 @@ async fn test_full_env_activation() {
         project.env_vars(),
         &default_env,
         CurrentEnvVarBehavior::Include,
-        None,
         false,
         false,
     )
@@ -92,7 +90,6 @@ async fn test_clean_env_activation() {
         project.env_vars(),
         &default_env,
         CurrentEnvVarBehavior::Clean,
-        None,
         false,
         false,
     )

--- a/crates/pixi_cli/src/run.rs
+++ b/crates/pixi_cli/src/run.rs
@@ -435,7 +435,6 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 let command_env = get_task_env(
                     &executable_task.run_environment,
                     args.clean_env || executable_task.task().clean_env(),
-                    Some(lock_file.as_lock_file()),
                     workspace.config().force_activate(),
                     workspace.config().experimental_activation_cache_usage(),
                 )

--- a/crates/pixi_cli/src/shell.rs
+++ b/crates/pixi_cli/src/shell.rs
@@ -336,8 +336,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let environment = workspace.environment_from_name_or_env_var(args.environment)?;
 
     // Make sure environment is up-to-date, default to install, users can avoid this with frozen or locked.
-    #[allow(unused_variables)]
-    let (lock_file_data, prefix) = get_update_lock_file_and_prefix(
+    let (_, prefix) = get_update_lock_file_and_prefix(
         &environment,
         Some(pixi_reporters::TopLevelProgress::from_global()),
         UpdateMode::QuickValidate,
@@ -351,14 +350,12 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         &InstallFilter::default(),
     )
     .await?;
-    let lock_file = lock_file_data.into_lock_file();
 
     // Get the environment variables we need to set activate the environment in the shell.
     let env = get_activated_environment_variables(
         workspace.env_vars(),
         &environment,
         CurrentEnvVarBehavior::Exclude,
-        Some(&lock_file),
         workspace.config().force_activate(),
         workspace.config().experimental_activation_cache_usage(),
     )

--- a/crates/pixi_cli/src/shell_hook.rs
+++ b/crates/pixi_cli/src/shell_hook.rs
@@ -3,7 +3,6 @@ use std::{collections::HashMap, default::Default, path::PathBuf};
 use clap::Parser;
 use miette::IntoDiagnostic;
 use pixi_config::{ConfigCli, ConfigCliActivation, ConfigCliPrompt};
-use rattler_lock::LockFile;
 use rattler_shell::{
     activation::{ActivationVariables, PathModificationBehavior},
     shell::{Shell, ShellEnum},
@@ -124,7 +123,6 @@ async fn generate_activation_script(
 /// activating the provided pixi environment.
 async fn generate_environment_json(
     environment: &Environment<'_>,
-    lock_file: &LockFile,
     force_activate: bool,
     experimental_cache: bool,
 ) -> miette::Result<String> {
@@ -132,7 +130,6 @@ async fn generate_environment_json(
         environment.workspace().env_vars(),
         environment,
         CurrentEnvVarBehavior::Exclude,
-        Some(lock_file),
         force_activate,
         experimental_cache,
     )
@@ -167,7 +164,9 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     let environment = workspace.environment_from_name_or_env_var(args.environment)?;
 
-    let (lock_file_data, _prefix) = get_update_lock_file_and_prefix(
+    // Run purely for the install/validation side effect; activation below
+    // needs no lock file.
+    let (_, _) = get_update_lock_file_and_prefix(
         &environment,
         Some(pixi_reporters::TopLevelProgress::from_global()),
         UpdateMode::QuickValidate,
@@ -186,7 +185,6 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         true => {
             generate_environment_json(
                 &environment,
-                &lock_file_data.into_lock_file(),
                 workspace.config().force_activate(),
                 workspace.config().experimental_activation_cache_usage(),
             )

--- a/crates/pixi_core/src/activation.rs
+++ b/crates/pixi_core/src/activation.rs
@@ -9,7 +9,6 @@ use itertools::Itertools;
 use miette::IntoDiagnostic;
 use pixi_manifest::EnvironmentName;
 use pixi_manifest::FeaturesExt;
-use rattler_lock::LockFile;
 use rattler_shell::{
     activation::{
         ActivationError::FailedToRunActivationScript, ActivationVariables, Activator,
@@ -38,11 +37,8 @@ pub enum CurrentEnvVarBehavior {
 struct ActivationCache {
     /// Hash of the environment that produced these activation results.
     /// Captures input env vars, activation scripts, project activation
-    /// env vars, and either:
-    /// - the prefix's install fingerprint (preferred — see
-    ///   `InstallPixiEnvironmentResult::installed_fingerprint`), or
-    /// - locked package URLs (legacy fallback when no fingerprint is
-    ///   stored next to the prefix).
+    /// env vars, and the prefix's install fingerprint (see
+    /// `InstallPixiEnvironmentResult::installed_fingerprint`).
     hash: EnvironmentHash,
     /// The environment variables set by the activation.
     environment_variables: HashMap<String, String>,
@@ -283,15 +279,12 @@ async fn try_get_valid_activation_cache(
 
 /// Runs and caches the activation script.
 ///
-/// The `_lock_file` parameter is retained for API stability (several
-/// callers still pass one) but is no longer consulted: the activation
-/// cache is now keyed on the prefix's install fingerprint instead of
-/// locked package URLs (see [`EnvironmentHash::for_activation`]).
-#[allow(clippy::needless_pass_by_value)]
+/// The activation cache is keyed on the prefix's install fingerprint
+/// (see [`EnvironmentHash::for_activation`]), so no lock file is
+/// needed here.
 pub async fn run_activation(
     environment: &Environment<'_>,
     env_var_behavior: &CurrentEnvVarBehavior,
-    _lock_file: Option<&LockFile>,
     force_activate: bool,
     experimental: bool,
 ) -> miette::Result<HashMap<String, String>> {
@@ -508,22 +501,16 @@ pub(crate) fn get_clean_environment_variables() -> HashMap<String, String> {
 /// variables from the project and based on the clean_env setting it will also add in the current
 /// shell environment variables.
 ///
-/// If a lock file is given this will also create/use an activated environment cache when possible.
+/// When `experimental` is set this will also create/use an activated environment cache keyed on
+/// the prefix's install fingerprint when possible.
 pub(crate) async fn initialize_env_variables(
     environment: &Environment<'_>,
     env_var_behavior: CurrentEnvVarBehavior,
-    lock_file: Option<&LockFile>,
     force_activate: bool,
     experimental: bool,
 ) -> miette::Result<HashMap<String, String>> {
-    let activation_env = run_activation(
-        environment,
-        &env_var_behavior,
-        lock_file,
-        force_activate,
-        experimental,
-    )
-    .await?;
+    let activation_env =
+        run_activation(environment, &env_var_behavior, force_activate, experimental).await?;
 
     // Get environment variables from the currently activated shell.
     let current_shell_env_vars = match env_var_behavior {
@@ -709,30 +696,18 @@ mod tests {
 
         // Without an install fingerprint, the cache is never written
         // even with experimental=true and a lock file present.
-        let env = run_activation(
-            &default_env,
-            &CurrentEnvVarBehavior::Include,
-            Some(&LockFile::default()),
-            false,
-            true,
-        )
-        .await
-        .unwrap();
+        let env = run_activation(&default_env, &CurrentEnvVarBehavior::Include, false, true)
+            .await
+            .unwrap();
         assert!(env.contains_key("CONDA_PREFIX"));
         assert!(!project.activation_env_cache_folder().exists());
 
         // Write a fingerprint marker so the cache becomes operative.
         write_fingerprint(&default_env.dir(), "000000000000000a").await;
 
-        let _env = run_activation(
-            &default_env,
-            &CurrentEnvVarBehavior::Include,
-            Some(&LockFile::default()),
-            false,
-            true,
-        )
-        .await
-        .unwrap();
+        let _env = run_activation(&default_env, &CurrentEnvVarBehavior::Include, false, true)
+            .await
+            .unwrap();
         assert!(project.activation_env_cache_folder().exists());
         let cache_file = project.default_environment().activation_cache_file_path();
         assert!(cache_file.exists());
@@ -742,30 +717,18 @@ mod tests {
         let contents = tokio_fs::read_to_string(&cache_file).await.unwrap();
         let modified = contents.replace("ACTIVATION123", "ACTIVATION456");
         tokio_fs::write(&cache_file, modified).await.unwrap();
-        let env = run_activation(
-            &default_env,
-            &CurrentEnvVarBehavior::Include,
-            Some(&LockFile::default()),
-            false,
-            true,
-        )
-        .await
-        .unwrap();
+        let env = run_activation(&default_env, &CurrentEnvVarBehavior::Include, false, true)
+            .await
+            .unwrap();
         assert_eq!(env.get("TEST").unwrap(), "ACTIVATION456");
 
         // Bumping the fingerprint mimics a fresh install with
         // different content — the cache key changes, so activation
         // runs again and overwrites the cache file.
         write_fingerprint(&default_env.dir(), "000000000000000b").await;
-        let env = run_activation(
-            &default_env,
-            &CurrentEnvVarBehavior::Include,
-            Some(&LockFile::default()),
-            false,
-            true,
-        )
-        .await
-        .unwrap();
+        let env = run_activation(&default_env, &CurrentEnvVarBehavior::Include, false, true)
+            .await
+            .unwrap();
         assert_eq!(env.get("TEST").unwrap(), "ACTIVATION123");
     }
 
@@ -790,15 +753,9 @@ mod tests {
         let default_env = project.default_environment();
         // A fingerprint marker is required for the cache to engage at all.
         write_fingerprint(&default_env.dir(), "00000000000000fb").await;
-        let env = run_activation(
-            &default_env,
-            &CurrentEnvVarBehavior::Include,
-            Some(&LockFile::default()),
-            false,
-            true,
-        )
-        .await
-        .unwrap();
+        let env = run_activation(&default_env, &CurrentEnvVarBehavior::Include, false, true)
+            .await
+            .unwrap();
         assert_eq!(env.get("TEST").unwrap(), "ACTIVATION123",);
 
         // Modify the variable in cache
@@ -823,15 +780,9 @@ mod tests {
         let default_env = project.default_environment();
         // Marker survives the manifest edit (same prefix dir).
         write_fingerprint(&default_env.dir(), "00000000000000fb").await;
-        let env = run_activation(
-            &default_env,
-            &CurrentEnvVarBehavior::Include,
-            Some(&LockFile::default()),
-            false,
-            true,
-        )
-        .await
-        .unwrap();
+        let env = run_activation(&default_env, &CurrentEnvVarBehavior::Include, false, true)
+            .await
+            .unwrap();
         assert_eq!(
             env.get("TEST").unwrap(),
             "ACTIVATION123",

--- a/crates/pixi_core/src/lock_file/resolve/build_dispatch.rs
+++ b/crates/pixi_core/src/lock_file/resolve/build_dispatch.rs
@@ -352,7 +352,6 @@ impl<'a> LazyBuildDispatch<'a> {
                     &self.project_env_vars,
                     &self.environment,
                     CurrentEnvVarBehavior::Exclude,
-                    None,
                     false,
                     false,
                 )

--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -1274,7 +1274,6 @@ impl LazyEnvironmentVariables for LazyPixiEnvironmentVars<'_> {
                 workspace.env_vars(),
                 &environment,
                 CurrentEnvVarBehavior::Exclude,
-                None,
                 false,
                 false,
             )

--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -1070,7 +1070,6 @@ pub async fn get_activated_environment_variables<'a>(
     project_env_vars: &'a HashMap<EnvironmentName, EnvironmentVars>,
     environment: &Environment<'_>,
     current_env_var_behavior: CurrentEnvVarBehavior,
-    lock_file: Option<&LockFile>,
     force_activate: bool,
     experimental_cache: bool,
 ) -> miette::Result<&'a HashMap<String, String>> {
@@ -1087,7 +1086,6 @@ pub async fn get_activated_environment_variables<'a>(
                     initialize_env_variables(
                         environment,
                         current_env_var_behavior,
-                        lock_file,
                         force_activate,
                         experimental_cache,
                     )
@@ -1101,7 +1099,6 @@ pub async fn get_activated_environment_variables<'a>(
                     initialize_env_variables(
                         environment,
                         current_env_var_behavior,
-                        lock_file,
                         force_activate,
                         experimental_cache,
                     )
@@ -1115,7 +1112,6 @@ pub async fn get_activated_environment_variables<'a>(
                     initialize_env_variables(
                         environment,
                         current_env_var_behavior,
-                        lock_file,
                         force_activate,
                         experimental_cache,
                     )

--- a/crates/pixi_task/src/executable_task.rs
+++ b/crates/pixi_task/src/executable_task.rs
@@ -532,7 +532,6 @@ fn get_export_specific_task_env(
 pub async fn get_task_env(
     environment: &Environment<'_>,
     clean_env: bool,
-    lock_file: Option<&LockFile>,
     force_activate: bool,
     experimental_cache: bool,
 ) -> miette::Result<HashMap<String, String>> {
@@ -547,7 +546,6 @@ pub async fn get_task_env(
             environment.workspace().env_vars(),
             environment,
             env_var_behavior,
-            lock_file,
             force_activate,
             experimental_cache,
         )
@@ -881,7 +879,7 @@ exit 0
         .unwrap();
 
         let environment = workspace.default_environment();
-        let env = get_task_env(&environment, false, None, false, false)
+        let env = get_task_env(&environment, false, false, false)
             .await
             .unwrap();
         assert_eq!(


### PR DESCRIPTION
### Description

Activating an environment used to require the parsed lock file: `run_activation` took an `Option<&LockFile>` that threaded through every caller up to `pixi run`, `pixi shell`, and `pixi shell-hook`. The parameter has been unused for a while (the activation cache is keyed on the installed environment's fingerprint instead) and was only kept around for API stability.

This change removes the parameter from the whole chain. Besides shedding dead API surface, it removes one of the places that force every `pixi run` invocation to keep a parsed lock file around, a prerequisite for making lock-file parsing lazily deferrable.

### How Has This Been Tested?

The full `pixi_core` and `pixi_task` unit suites pass, including the activation-cache tests that exercise `run_activation` without the parameter. The three `test_activation` integration tests (pixi-only, full, and clean-env activation) pass against a real prefix. `cargo clippy --all-targets -- -D warnings` and `cargo fmt` are clean across the touched crates.

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.