### PR TITLE
fix: key the task cache on installed environment markers instead of locked URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7215,6 +7215,7 @@ dependencies = [
  "pixi_glob",
  "pixi_manifest",
  "pixi_progress",
+ "pixi_utils",
  "rattler_conda_types",
  "rattler_lock",
  "rayon",

--- a/crates/pixi_cli/src/run.rs
+++ b/crates/pixi_cli/src/run.rs
@@ -294,6 +294,8 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     // task.
     let mut task_idx = 0;
     let mut task_envs = HashMap::new();
+    // Environments whose prefix has already been ensured in this run.
+    let mut ensured_prefixes = HashSet::new();
     let signal = KillSignal::default();
     // make sure that child processes are killed when pixi stops
     let _drop_guard = signal.clone().drop_guard();
@@ -373,12 +375,30 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             continue;
         }
 
-        // check task cache
-        let task_cache = match executable_task
-            .can_skip(lock_file.as_lock_file())
-            .await
-            .into_diagnostic()?
+        // Ensure the environment's prefix is up-to-date *before* consulting
+        // the task cache: the cache key is derived from the installed
+        // fingerprint next to the prefix, so the prefix must reflect the
+        // (possibly just re-solved) lock file first. Otherwise a lock-file
+        // change without an intervening install could still match a cache
+        // entry recorded for the old prefix — skipping both the task and the
+        // install that would have reconciled the environment.
+        // `QuickValidate` makes this a marker read + hash when nothing
+        // changed.
+        if args.lock_and_install_config.allow_installs()
+            && ensured_prefixes.insert(executable_task.run_environment.clone())
         {
+            lock_file
+                .prefix(
+                    &executable_task.run_environment,
+                    UpdateMode::QuickValidate,
+                    &ReinstallPackages::default(),
+                    &pixi_core::environment::InstallFilter::default(),
+                )
+                .await?;
+        }
+
+        // check task cache
+        let task_cache = match executable_task.can_skip().await.into_diagnostic()? {
             CanSkip::No(cache) => cache,
             CanSkip::Yes => {
                 let args_text = if !executable_task.args().is_empty() {
@@ -407,19 +427,11 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             Entry::Vacant(entry) => {
                 // Check if we allow installs
                 if args.lock_and_install_config.allow_installs() {
-                    // Ensure there is a valid prefix
-                    lock_file
-                        .prefix(
-                            &executable_task.run_environment,
-                            UpdateMode::QuickValidate,
-                            &ReinstallPackages::default(),
-                            &pixi_core::environment::InstallFilter::default(),
-                        )
-                        .await?;
-
-                    // Validate that the auto-detected machine (or explicit
-                    // `--platform`) can run what was installed, comparing
-                    // against the resolved/minimum platforms in conda-meta/pixi.
+                    // The prefix was already ensured before the task-cache
+                    // check above. Validate that the auto-detected machine
+                    // (or explicit `--platform`) can run what was installed,
+                    // comparing against the resolved/minimum platforms in
+                    // conda-meta/pixi.
                     pixi_core::workspace::virtual_packages::verify_run_platform(
                         &executable_task.run_environment,
                         user_platform.as_ref(),
@@ -467,7 +479,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
         // Compute post-run hash, warn on missing globs, and update the cache
         let post_hash = executable_task
-            .compute_post_run_hash(lock_file.as_lock_file(), task_cache)
+            .compute_post_run_hash(task_cache)
             .await
             .into_diagnostic()?;
         if let Some(ref hash) = post_hash {

--- a/crates/pixi_core/src/environment/mod.rs
+++ b/crates/pixi_core/src/environment/mod.rs
@@ -16,7 +16,7 @@ use pixi_spec::{GitSpec, PixiSpec};
 use pixi_utils::EnvironmentFingerprint;
 use pixi_utils::{prefix::Prefix, rlimit::try_increase_rlimit_to_sensible};
 use rattler_conda_types::{GenericVirtualPackage, Platform};
-use rattler_lock::{LockFile, LockedPackage};
+use rattler_lock::LockedPackage;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 use std::{
@@ -108,45 +108,10 @@ async fn prefix_location_changed(
 pub struct EnvironmentHash(String);
 
 impl EnvironmentHash {
-    /// Compute a hash that combines the project + locked-environment
-    /// state.
+    /// Compute the cache key for prefix-content-dependent caches (the
+    /// activation env-var cache and the task cache).
     ///
-    /// Used for **task** caching: a task's cached result is keyed on
-    /// inputs the user can change without going through an install
-    /// (manifest, lock file, env vars, activation scripts), so this
-    /// flavour folds locked package URLs into the hash directly.
-    ///
-    /// The activation cache uses [`Self::for_activation`] instead —
-    /// see the docs there for why URL-based hashing is too coarse for
-    /// that use case.
-    pub fn from_environment(
-        run_environment: &workspace::Environment<'_>,
-        input_environment_variables: &HashMap<String, Option<String>>,
-        lock_file: &LockFile,
-    ) -> Self {
-        let mut hasher = Xxh3::new();
-        Self::hash_common_inputs(&mut hasher, run_environment, input_environment_variables);
-
-        // Hash the packages
-        let mut urls = Vec::new();
-        if let Some(env) = lock_file.environment(run_environment.name().as_str())
-            && let Some(best) = run_environment.best_declared_platform()
-            && let Some(lock_platform) = lock_file.platform(best.name().as_str())
-            && let Some(packages) = env.packages(lock_platform)
-        {
-            for package in packages {
-                urls.push(package.location().to_string())
-            }
-        }
-        urls.sort();
-        urls.hash(&mut hasher);
-
-        EnvironmentHash(format!("{:x}", hasher.finish()))
-    }
-
-    /// Compute the cache key for the activation env-var map.
-    ///
-    /// Activation results depend on:
+    /// Results depend on:
     /// 1. Shell input env vars referenced by the activation scripts.
     /// 2. The project's activation scripts and activation env.
     /// 3. What is actually installed in the prefix.
@@ -157,11 +122,10 @@ impl EnvironmentHash {
     /// [`pixi_utils::EnvironmentFingerprint`].
     ///
     /// We deliberately do **not** fold locked package URLs into this
-    /// hash like [`Self::from_environment`] does: for source
-    /// packages a URL is a stable path string that doesn't change
-    /// when the source content (and therefore the built artifact)
-    /// changes, so a URL-based key would falsely accept stale
-    /// activation env vars after a source-rebuild. The fingerprint
+    /// hash: for source packages a URL is a stable path string that
+    /// doesn't change when the source content (and therefore the
+    /// built artifact) changes, so a URL-based key would falsely
+    /// accept stale results after a source-rebuild. The fingerprint
     /// is the smallest authoritative summary of the prefix's
     /// content, so URLs add no signal beyond it.
     pub fn for_activation(
@@ -175,10 +139,10 @@ impl EnvironmentHash {
         EnvironmentHash(format!("{:x}", hasher.finish()))
     }
 
-    /// Fold every input shared by both hash flavours into `hasher`:
-    /// the shell input env vars (sorted by key for determinism),
-    /// the activation scripts in declaration order, and the project
-    /// activation env (sorted by key).
+    /// Fold the non-prefix inputs into `hasher`: the shell input env
+    /// vars (sorted by key for determinism), the activation scripts in
+    /// declaration order, and the project activation env (sorted by
+    /// key).
     fn hash_common_inputs(
         hasher: &mut Xxh3,
         run_environment: &workspace::Environment<'_>,

--- a/crates/pixi_core/src/workspace/environment.rs
+++ b/crates/pixi_core/src/workspace/environment.rs
@@ -120,6 +120,18 @@ impl<'p> Environment<'p> {
         }
     }
 
+    /// The [`LockedEnvironmentHash`](crate::environment::LockedEnvironmentHash)
+    /// recorded in this environment's `conda-meta/pixi` marker file by the
+    /// last prefix install/validation: a digest of every locked package
+    /// (conda *and* pypi) the prefix was installed from. `None` when the
+    /// environment isn't installed yet or the marker is unreadable.
+    pub fn installed_lock_file_hash(&self) -> Option<crate::environment::LockedEnvironmentHash> {
+        match crate::environment::read_environment_file(&self.dir()) {
+            Ok(Some(file)) => Some(file.environment_lock_file_hash),
+            _ => None,
+        }
+    }
+
     /// The name of the workspace platform this environment was last installed
     /// for, recovered by matching the resolved platform in `conda-meta/pixi`
     /// (subdir + virtual packages) against the declared platforms. Lets `pixi

--- a/crates/pixi_task/Cargo.toml
+++ b/crates/pixi_task/Cargo.toml
@@ -23,6 +23,7 @@ pixi_core = { workspace = true }
 pixi_glob = { workspace = true }
 pixi_manifest = { workspace = true, features = ["rattler_lock"] }
 pixi_progress = { workspace = true }
+pixi_utils = { workspace = true }
 rattler_conda_types = { workspace = true }
 rattler_lock = { workspace = true }
 rayon = { workspace = true }

--- a/crates/pixi_task/src/executable_task.rs
+++ b/crates/pixi_task/src/executable_task.rs
@@ -303,29 +303,43 @@ impl<'p> ExecutableTask<'p> {
 
     /// Compute the post-run task hash by updating inputs and outputs.
     /// This does not emit any warnings; it only reflects the current filesystem state.
+    ///
+    /// The environment components of the key are always re-derived from the
+    /// current on-disk markers: `previous_hash` may have been computed
+    /// before an install that changed them.
+    ///
+    /// Returns `Ok(None)` when the environment has no completed-install
+    /// fingerprint marker (e.g. `--no-install` runs before any install):
+    /// no cache key can be derived, so nothing will be saved. In that case
+    /// the caller also gets no hash to feed
+    /// [`Self::warn_on_missing_globs`], so missing-glob warnings are
+    /// skipped on such runs.
     pub async fn compute_post_run_hash(
         &self,
-        lock_file: &LockFile,
         previous_hash: Option<TaskHash>,
     ) -> Result<Option<TaskHash>, InputHashesError> {
-        // Start from provided hash if available, otherwise from current task state.
-        // If neither is available, create a minimal hash so we can report warnings
-        // and make a consistent caching decision.
-        let mut hash = if let Some(hash) = previous_hash {
-            hash
-        } else if let Some(hash) = TaskHash::from_task(self, lock_file).await? {
-            hash
-        } else {
-            TaskHash {
+        let Some((environment, locked_environment)) = TaskHash::environment_hashes(self) else {
+            // No install fingerprint: task caching is disengaged.
+            return Ok(None);
+        };
+
+        // Start from the hash `can_skip` computed if available, otherwise
+        // from a minimal hash, so we can report warnings and make a
+        // consistent caching decision. Inputs and outputs are refreshed
+        // from the post-run filesystem below either way.
+        let mut hash = match previous_hash {
+            Some(mut hash) => {
+                hash.environment = environment;
+                hash.locked_environment = locked_environment;
+                hash
+            }
+            None => TaskHash {
                 command: self.full_command().ok().flatten(),
                 inputs: None,
                 outputs: None,
-                environment: pixi_core::environment::EnvironmentHash::from_environment(
-                    &self.run_environment,
-                    &std::collections::HashMap::new(),
-                    lock_file,
-                ),
-            }
+                environment,
+                locked_environment,
+            },
         };
 
         // Update inputs/outputs based on the current filesystem
@@ -398,7 +412,10 @@ impl<'p> ExecutableTask<'p> {
     /// `CanSkip::No` and includes the hash of the task that caused the task
     /// to not be skipped - we can use this later to update the cache file
     /// quickly.
-    pub async fn can_skip(&self, lock_file: &LockFile) -> Result<CanSkip, std::io::Error> {
+    ///
+    /// Without a completed-install fingerprint marker for the environment no
+    /// task hash can be derived, so the task is never skipped.
+    pub async fn can_skip(&self) -> Result<CanSkip, std::io::Error> {
         tracing::info!("Checking if task can be skipped");
         let args_hash = TaskHash::task_args_hash(self).unwrap_or_default();
         let cache_name = self.cache_name(args_hash);
@@ -406,7 +423,7 @@ impl<'p> ExecutableTask<'p> {
         if cache_file.exists() {
             let cache = tokio_fs::read_to_string(&cache_file).await?;
             let cache: TaskCache = serde_json::from_str(&cache)?;
-            let hash = TaskHash::from_task(self, lock_file).await;
+            let hash = TaskHash::from_task(self).await;
             if let Ok(Some(hash)) = hash {
                 if hash.computation_hash() != cache.hash {
                     return Ok(CanSkip::No(Some(hash)));
@@ -891,5 +908,185 @@ exit 0
                 .to_string_lossy()
                 .to_string()
         );
+    }
+
+    /// Write a completed-install fingerprint marker for `env_dir` via the
+    /// install lock, the way a finished install does, so fingerprint-keyed
+    /// caching engages. `fp` must be 16 hex chars (the on-disk width).
+    async fn write_fingerprint(env_dir: &Path, fp: &str) {
+        pixi_utils::EnvironmentLock::acquire(env_dir)
+            .await
+            .unwrap()
+            .finish(&pixi_utils::EnvironmentFingerprint::from_string(
+                fp.to_string(),
+            ))
+            .await
+            .unwrap();
+    }
+
+    /// Build a workspace rooted in `dir` whose `test` task declares an input
+    /// glob, plus the matching input file, so [`TaskHash::from_task`]
+    /// produces input hashes and the task cache participates.
+    fn cacheable_task_workspace(dir: &Path) -> Workspace {
+        fs_err::write(dir.join("input.txt"), "input-contents").unwrap();
+        let manifest = format!(
+            "{PROJECT_BOILERPLATE}\n[tasks]\ntest = {{ cmd = \"echo hi\", inputs = [\"input.txt\"] }}\n"
+        );
+        Workspace::from_str(dir.join("pixi.toml").as_path(), &manifest).unwrap()
+    }
+
+    /// The task hash is keyed on the prefix's install fingerprint: stable
+    /// while the fingerprint is unchanged, different once a re-install
+    /// records different content.
+    #[tokio::test]
+    async fn test_task_hash_keyed_on_install_fingerprint() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let workspace = cacheable_task_workspace(temp_dir.path());
+        let task = task_from_snippet(&workspace, "test");
+        let env_dir = workspace.default_environment().dir();
+
+        write_fingerprint(&env_dir, "000000000000000a").await;
+        let hash_a = TaskHash::from_task(&task)
+            .await
+            .unwrap()
+            .expect("inputs are declared, so a hash must be computed")
+            .computation_hash();
+
+        // Recomputing under the same fingerprint gives the same key.
+        let hash_a2 = TaskHash::from_task(&task)
+            .await
+            .unwrap()
+            .unwrap()
+            .computation_hash();
+        assert_eq!(hash_a, hash_a2);
+
+        // A re-install with different content changes the key.
+        write_fingerprint(&env_dir, "000000000000000b").await;
+        let hash_b = TaskHash::from_task(&task)
+            .await
+            .unwrap()
+            .unwrap()
+            .computation_hash();
+        assert_ne!(
+            hash_a, hash_b,
+            "the task hash must change when the installed fingerprint changes"
+        );
+    }
+
+    /// Write a minimal `conda-meta/pixi` environment file recording
+    /// `lock_hash` as the locked-environment digest, mirroring what a
+    /// prefix install persists.
+    fn write_environment_file(env_dir: &Path, lock_hash: &str) {
+        let conda_meta = env_dir.join(pixi_consts::consts::CONDA_META_DIR);
+        fs_err::create_dir_all(&conda_meta).unwrap();
+        fs_err::write(
+            conda_meta.join(pixi_consts::consts::ENVIRONMENT_FILE_NAME),
+            format!(
+                r#"{{"manifest_path":"pixi.toml","environment_name":"default","pixi_version":"0.0.0","environment_lock_file_hash":"{lock_hash}"}}"#
+            ),
+        )
+        .unwrap();
+    }
+
+    /// The task hash also folds the locked-environment digest recorded in
+    /// `conda-meta/pixi`: it covers pypi packages, which the conda install
+    /// fingerprint cannot see, so a pypi-only change must still invalidate
+    /// the task cache.
+    #[tokio::test]
+    async fn test_task_hash_keyed_on_installed_lock_hash() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let workspace = cacheable_task_workspace(temp_dir.path());
+        let task = task_from_snippet(&workspace, "test");
+        let env_dir = workspace.default_environment().dir();
+
+        write_fingerprint(&env_dir, "000000000000000a").await;
+        let hash_without_marker = TaskHash::from_task(&task)
+            .await
+            .unwrap()
+            .unwrap()
+            .computation_hash();
+
+        // Recording an environment file (as a prefix install does) changes
+        // the key...
+        write_environment_file(&env_dir, "lock-hash-1");
+        let hash_a = TaskHash::from_task(&task)
+            .await
+            .unwrap()
+            .unwrap()
+            .computation_hash();
+        assert_ne!(hash_without_marker, hash_a);
+
+        // ...and a different locked-environment digest under the same
+        // install fingerprint (a pypi bump leaves the conda fingerprint
+        // unchanged) changes it again.
+        write_environment_file(&env_dir, "lock-hash-2");
+        let hash_b = TaskHash::from_task(&task)
+            .await
+            .unwrap()
+            .unwrap()
+            .computation_hash();
+        assert_ne!(
+            hash_a, hash_b,
+            "the task hash must change when the installed locked-environment digest changes"
+        );
+    }
+
+    /// Without a completed-install fingerprint marker (e.g. `--no-install`
+    /// before any install, or an interrupted install) task caching
+    /// disengages: no hash is computed, nothing is saved, nothing skips.
+    #[tokio::test]
+    async fn test_task_cache_disengages_without_fingerprint() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let workspace = cacheable_task_workspace(temp_dir.path());
+        let task = task_from_snippet(&workspace, "test");
+
+        // No marker was ever written: no key can be computed...
+        assert!(
+            TaskHash::from_task(&task).await.unwrap().is_none(),
+            "no task hash may be derived without an install fingerprint"
+        );
+        // ...so a run saves nothing...
+        assert!(
+            task.compute_post_run_hash(None).await.unwrap().is_none(),
+            "no post-run hash may be saved without an install fingerprint"
+        );
+        // ...and the task is never skipped.
+        assert!(matches!(task.can_skip().await.unwrap(), CanSkip::No(None)));
+    }
+
+    /// End-to-end cache round-trip: a saved entry skips while the
+    /// fingerprint is unchanged, misses after a re-install records a new
+    /// fingerprint, and disengages when the marker disappears.
+    #[tokio::test]
+    async fn test_task_cache_follows_install_fingerprint() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let workspace = cacheable_task_workspace(temp_dir.path());
+        let task = task_from_snippet(&workspace, "test");
+        let env_dir = workspace.default_environment().dir();
+
+        write_fingerprint(&env_dir, "000000000000000a").await;
+
+        // Nothing cached yet.
+        assert!(matches!(task.can_skip().await.unwrap(), CanSkip::No(_)));
+
+        // Simulate a successful run: compute and persist the cache entry.
+        let post_hash = task.compute_post_run_hash(None).await.unwrap();
+        assert!(post_hash.is_some());
+        task.save_cache(post_hash).await.unwrap();
+
+        // Unchanged fingerprint and inputs: the task can be skipped.
+        assert!(matches!(task.can_skip().await.unwrap(), CanSkip::Yes));
+
+        // A re-install with different content invalidates the entry.
+        write_fingerprint(&env_dir, "000000000000000b").await;
+        assert!(
+            matches!(task.can_skip().await.unwrap(), CanSkip::No(Some(_))),
+            "a changed install fingerprint must invalidate the cached entry"
+        );
+
+        // A missing marker (interrupted install) disengages caching even
+        // though a cache file exists on disk.
+        fs_err::remove_dir_all(env_dir.join("conda-meta")).unwrap();
+        assert!(matches!(task.can_skip().await.unwrap(), CanSkip::No(None)));
     }
 }

--- a/crates/pixi_task/src/task_hash.rs
+++ b/crates/pixi_task/src/task_hash.rs
@@ -1,7 +1,6 @@
 use miette::Diagnostic;
-use pixi_core::environment::EnvironmentHash;
+use pixi_core::environment::{EnvironmentHash, LockedEnvironmentHash};
 use pixi_manifest::task::TemplateStringError;
-use rattler_lock::LockFile;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
@@ -65,7 +64,15 @@ pub struct TaskCache {
 /// with the [`TaskHash::computation_hash`] method.
 #[derive(Debug)]
 pub struct TaskHash {
+    /// Key over the prefix's installed conda content and the activation
+    /// inputs, see [`TaskHash::environment_hashes`].
     pub environment: EnvironmentHash,
+    /// Digest of the locked packages (conda *and* pypi) the prefix was last
+    /// installed from, read from the `conda-meta/pixi` marker. Covers what
+    /// the conda install fingerprint cannot see: pypi packages leave no
+    /// trace there, but their locked URLs are folded into this digest at
+    /// install time. `None` when the marker was never recorded.
+    pub locked_environment: Option<LockedEnvironmentHash>,
     pub command: Option<String>,
     pub inputs: Option<InputHashes>,
     pub outputs: Option<OutputHashes>,
@@ -73,10 +80,20 @@ pub struct TaskHash {
 
 impl TaskHash {
     /// Constructs an instance from an executable task.
-    pub async fn from_task(
-        task: &ExecutableTask<'_>,
-        lock_file: &LockFile,
-    ) -> Result<Option<Self>, InputHashesError> {
+    ///
+    /// Returns `Ok(None)` when no cache key can be derived because the
+    /// environment has no completed-install fingerprint (see
+    /// [`Self::environment_hashes`]), or when the task declares no inputs
+    /// or outputs (there is nothing to cache) — in both cases task caching
+    /// disengages.
+    pub async fn from_task(task: &ExecutableTask<'_>) -> Result<Option<Self>, InputHashesError> {
+        // Probe the cheap marker-derived key components first: without them
+        // there is no cache key, so skip the (potentially expensive) file
+        // hashing entirely.
+        let Some((environment, locked_environment)) = Self::environment_hashes(task) else {
+            return Ok(None);
+        };
+
         let input_hashes = InputHashes::from_task(task).await?;
         let output_hashes = OutputHashes::from_task(task).await?;
 
@@ -88,13 +105,38 @@ impl TaskHash {
             command: task.full_command().ok().flatten(),
             outputs: output_hashes,
             inputs: input_hashes,
-            // Skipping environment variables used for caching the task
-            environment: EnvironmentHash::from_environment(
-                &task.run_environment,
-                &HashMap::new(),
-                lock_file,
-            ),
+            environment,
+            locked_environment,
         }))
+    }
+
+    /// The environment-derived components of the task-cache key, read from
+    /// the markers a completed install leaves next to the prefix (no lock
+    /// file needed):
+    ///
+    /// - an [`EnvironmentHash`] keyed on the install fingerprint
+    ///   ([`pixi_utils::EnvironmentFingerprint`]), which follows the
+    ///   *installed* conda content — so a source rebuild invalidates the
+    ///   cache while lock-file churn that doesn't change the prefix does
+    ///   not;
+    /// - the [`LockedEnvironmentHash`] recorded in `conda-meta/pixi`, which
+    ///   also covers pypi packages (invisible to the conda fingerprint).
+    ///
+    /// Returns `None` when no completed install recorded a fingerprint
+    /// (never installed, interrupted install, or `--no-install` runs);
+    /// callers treat that as "task caching disengaged".
+    pub(crate) fn environment_hashes(
+        task: &ExecutableTask<'_>,
+    ) -> Option<(EnvironmentHash, Option<LockedEnvironmentHash>)> {
+        let fingerprint = pixi_utils::EnvironmentFingerprint::read(&task.run_environment.dir())?;
+        let environment = EnvironmentHash::for_activation(
+            &task.run_environment,
+            // Environment variables are deliberately not part of the task
+            // cache key.
+            &HashMap::new(),
+            &fingerprint,
+        );
+        Some((environment, task.run_environment.installed_lock_file_hash()))
     }
 
     pub async fn update_output(
@@ -120,6 +162,7 @@ impl TaskHash {
         self.inputs.hash(&mut hasher);
         self.outputs.hash(&mut hasher);
         self.environment.hash(&mut hasher);
+        self.locked_environment.hash(&mut hasher);
         ComputationHash(format!("{:x}", hasher.finish()))
     }
 


### PR DESCRIPTION
### Description

The task cache decided whether a cached task result was still valid by hashing the locked package URLs of the task's environment. That key has two problems. For source packages a URL is a stable path that doesn't change when the package's content (and therefore the built artifact) changes, so an edit could incorrectly keep a task-cache hit. And computing the key required the parsed lock file on every `pixi run`, even when nothing changed at all.

Task hashes are now keyed on what is actually installed: the install fingerprint recorded in the environment's markers, combined with the locked-environment digest from `conda-meta/pixi` so that PyPI-only changes stay visible. This is the same keying the activation cache already uses, for the same reason.

Two behavioral consequences worth calling out. When no install fingerprint exists, for example `--no-install` against a prefix that was never materialized, task caching now disengages and the task simply runs, instead of trusting a URL-derived key. And existing task caches invalidate once on upgrade because the hash formula changed.

### Open Questions

- The pre-run flow now ensures the prefix is up to date before consulting the cache, so a cache decision is always made against the installed state. This means `pixi run` materializes the prefix even when the task turns out to be a cache hit, where the old code could sometimes skip that work against a stale prefix. That seems like the right trade for correctness, but it is a latency change on the cache-hit path.

### How Has This Been Tested?

Four new `pixi_task` tests pin the new behavior: the task hash follows the install fingerprint across recomputes and re-installs, additionally folds the `conda-meta/pixi` locked-environment digest so a PyPI-only change still invalidates, disengages entirely when no fingerprint marker exists (nothing skips, nothing is saved), and an end-to-end cache round-trip skips on an unchanged fingerprint, misses after a simulated re-install, and disengages when the marker disappears. The full `pixi_task` and `pixi_core` unit suites and the task-related integration tests pass; `cargo clippy --all-targets -- -D warnings` and `cargo fmt` are clean across the touched crates.

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.